### PR TITLE
feat: support adding breakpoints (close #107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
 				"configuration": "./languages/vue-language-configuration.json"
 			}
 		],
+		"breakpoints": [
+			{
+				"language": "vue"
+			}
+		],
 		"configuration": {
 			"type": "object",
 			"title": "Volar",


### PR DESCRIPTION
Closes #107 

![图片](https://user-images.githubusercontent.com/17216317/115954926-331fe280-a526-11eb-9cd5-d0159791047a.png)

@odex21 There may be a bug from the "Debugger for Firefox" VS Code extension, and adding breakpoints may not have effects, so you may need "Debugger for Chrome" VS Code extension and use Chrome to debug your code.
