### PR TITLE
fix: typo, TarNameCase -> TagNameCase

### DIFF
--- a/packages/shared/src/requests.ts
+++ b/packages/shared/src/requests.ts
@@ -52,7 +52,7 @@ export namespace GetServerNameCasesRequest {
 export namespace GetClientAttrNameCaseRequest {
 	export const type: vscode.RequestType<vscode.TextDocumentIdentifier, 'kebabCase' | 'pascalCase', any> = new rpc.RequestType('volar/getAttrNameCaseClient');
 }
-export namespace GetClientTarNameCaseRequest {
+export namespace GetClientTagNameCaseRequest {
 	export const type: vscode.RequestType<vscode.TextDocumentIdentifier, 'both' | 'kebabCase' | 'pascalCase', any> = new rpc.RequestType('volar/getTagNameCaseClient');
 }
 export namespace RemoveAllRefSugars {

--- a/packages/vscode-client/src/features/tagNameCase.ts
+++ b/packages/vscode-client/src/features/tagNameCase.ts
@@ -11,7 +11,7 @@ export async function activate(context: vscode.ExtensionContext, languageClient:
 		await shared.sleep(100);
 	}
 
-	languageClient.onRequest(shared.GetClientTarNameCaseRequest.type, async handler => {
+	languageClient.onRequest(shared.GetClientTagNameCaseRequest.type, async handler => {
 		let tagCase = tagCases.get(handler.uri);
 		if (tagCase === 'unsure') {
 			const templateCases = await languageClient.sendRequest(shared.GetServerNameCasesRequest.type, handler);

--- a/packages/vscode-server/src/features/lspFeatures.ts
+++ b/packages/vscode-server/src/features/lspFeatures.ts
@@ -18,7 +18,7 @@ export function register(
 				handler.position,
 				handler.context,
 				{
-					tag: () => connection.sendRequest(shared.GetClientTarNameCaseRequest.type, {
+					tag: () => connection.sendRequest(shared.GetClientTagNameCaseRequest.type, {
 						uri: handler.textDocument.uri
 					}),
 					attr: () => connection.sendRequest(shared.GetClientAttrNameCaseRequest.type, {


### PR DESCRIPTION
I found a typo, fixed it.

**typo**:

```
volar$ rg "GetClientTarNameCaseRequest" packages
packages/shared/src/requests.ts
55:export namespace GetClientTarNameCaseRequest {

packages/vscode-server/src/features/lspFeatures.ts
21:					tag: () => connection.sendRequest(shared.GetClientTarNameCaseRequest.type, {

packages/vscode-client/src/features/tagNameCase.ts
14:	languageClient.onRequest(shared.GetClientTarNameCaseRequest.type, async handler => {
```