### PR TITLE
Support for Vue 2 template

### DIFF
--- a/packages/vscode-vue-languageservice/src/generators/template.ts
+++ b/packages/vscode-vue-languageservice/src/generators/template.ts
@@ -484,7 +484,7 @@ export function generate(
 				prop.type === CompilerDOM.NodeTypes.DIRECTIVE
 				&& prop.name === 'model'
 			) {
-				write('props', 'modelValue', prop.loc.start.offset, prop.loc.start.offset + 'v-model'.length, false, false);
+				write('props', getModelValuePropName(node.tag), prop.loc.start.offset, prop.loc.start.offset + 'v-model'.length, false, false);
 			}
 			else if (
 				prop.type === CompilerDOM.NodeTypes.ATTRIBUTE
@@ -625,7 +625,7 @@ export function generate(
 				&& (!prop.exp || prop.exp.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION)
 			) {
 
-				const propName_1 = prop.arg?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION ? prop.arg.content : 'modelValue';
+				const propName_1 = prop.arg?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION ? prop.arg.content : getModelValuePropName(node.tag);
 				const propName_2 = hyphenate(propName_1) === propName_1 ? camelize(propName_1) : propName_1;
 				const propValue = prop.exp?.content ?? 'undefined';
 				const isClassOrStyleAttr = ['style', 'class'].includes(propName_2);
@@ -1359,4 +1359,14 @@ function keepHyphenateName(oldName: string, newName: string) {
 		return hyphenate(newName);
 	}
 	return newName
+}
+// https://github.com/vuejs/vue-next/blob/master/packages/compiler-dom/src/transforms/vModel.ts#L49-L51
+function getModelValuePropName(tag: string) {
+	if (
+		tag === 'input' ||
+		tag === 'textarea' ||
+		tag === 'select'
+	) return 'value';
+
+	return 'modelValue';
 }

--- a/packages/vscode-vue-languageservice/src/generators/template.ts
+++ b/packages/vscode-vue-languageservice/src/generators/template.ts
@@ -40,6 +40,7 @@ export const transformContext: CompilerDOM.TransformContext = {
 export function generate(
 	sourceLang: 'html' | 'pug',
 	templateAst: CompilerDOM.RootNode,
+	isVue2: boolean,
 	componentNames: string[] = [],
 	cssScopedClasses: string[] = [],
 	htmlToTemplate: (htmlStart: number, htmlEnd: number) => number | undefined,
@@ -484,7 +485,7 @@ export function generate(
 				prop.type === CompilerDOM.NodeTypes.DIRECTIVE
 				&& prop.name === 'model'
 			) {
-				write('props', getModelValuePropName(node.tag), prop.loc.start.offset, prop.loc.start.offset + 'v-model'.length, false, false);
+				write('props', getModelValuePropName(node.tag, isVue2), prop.loc.start.offset, prop.loc.start.offset + 'v-model'.length, false, false);
 			}
 			else if (
 				prop.type === CompilerDOM.NodeTypes.ATTRIBUTE
@@ -625,7 +626,7 @@ export function generate(
 				&& (!prop.exp || prop.exp.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION)
 			) {
 
-				const propName_1 = prop.arg?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION ? prop.arg.content : getModelValuePropName(node.tag);
+				const propName_1 = prop.arg?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION ? prop.arg.content : getModelValuePropName(node.tag, isVue2);
 				const propName_2 = hyphenate(propName_1) === propName_1 ? camelize(propName_1) : propName_1;
 				const propValue = prop.exp?.content ?? 'undefined';
 				const isClassOrStyleAttr = ['style', 'class'].includes(propName_2);
@@ -1361,11 +1362,12 @@ function keepHyphenateName(oldName: string, newName: string) {
 	return newName
 }
 // https://github.com/vuejs/vue-next/blob/master/packages/compiler-dom/src/transforms/vModel.ts#L49-L51
-function getModelValuePropName(tag: string) {
+function getModelValuePropName(tag: string, isVue2: boolean) {
 	if (
 		tag === 'input' ||
 		tag === 'textarea' ||
-		tag === 'select'
+		tag === 'select' ||
+		isVue2
 	) return 'value';
 
 	return 'modelValue';

--- a/packages/vscode-vue-languageservice/src/generators/template_scriptSetup.ts
+++ b/packages/vscode-vue-languageservice/src/generators/template_scriptSetup.ts
@@ -3,18 +3,14 @@ import * as CompilerCore from '@vue/compiler-dom';
 import { transformContext } from './template';
 
 
-export function generate(html: string) {
+export function generate(node: CompilerDOM.RootNode) {
 
-	let node: CompilerDOM.RootNode;
 	let text = '';
 	const tags = new Set<string>();
 
-	try {
-		node = CompilerDOM.compile(html, { onError: () => { } }).ast;
-		for (const child of node.children) {
-			visitNode(child);
-		}
-	} catch { }
+	for (const child of node.children) {
+		visitNode(child);
+	}
 
 	return {
 		text,

--- a/packages/vscode-vue-languageservice/src/languageService.ts
+++ b/packages/vscode-vue-languageservice/src/languageService.ts
@@ -64,6 +64,7 @@ export function getDocumentLanguageService(
 ) {
 	const cache = new Map<string, [number, html.HTMLDocument]>();
 	const context: HtmlLanguageServiceContext = {
+		isVue2Mode: false,
 		modules: {
 			typescript: modules.typescript,
 			emmet,
@@ -155,7 +156,13 @@ export function createLanguageService(
 		},
 	}
 
+	const tsconfigFile = upath.join(vueHost.getCurrentDirectory(), 'tsconfig.json');
+	const jsconfigFile = upath.join(vueHost.getCurrentDirectory(), 'jsconfig.json');
+	const configFile = ts.sys.fileExists(tsconfigFile) ? tsconfigFile : ts.sys.fileExists(jsconfigFile) ? jsconfigFile : undefined;
+	const config = configFile ? shared.createParsedCommandLine(ts, ts.sys, configFile) : undefined;
+
 	const context: ApiLanguageServiceContext = {
+		isVue2Mode: config?.raw.vueCompilerOptions?.experimentalCompatMode === 2,
 		modules: {
 			typescript: modules.typescript,
 			emmet,

--- a/packages/vscode-vue-languageservice/src/sourceFile.ts
+++ b/packages/vscode-vue-languageservice/src/sourceFile.ts
@@ -90,7 +90,7 @@ export function createSourceFile(
 			};
 		}
 	});
-	const sfcTemplateCompileResult = useSfcTemplateCompileResult(computed(() => sfcTemplateData.value?.htmlTextDocument));
+	const sfcTemplateCompileResult = useSfcTemplateCompileResult(computed(() => sfcTemplateData.value?.htmlTextDocument), context.isVue2Mode);
 	const sfcTemplateScript = useSfcTemplateScript(
 		untrack(() => document.value),
 		computed(() => descriptor.template),

--- a/packages/vscode-vue-languageservice/src/types.ts
+++ b/packages/vscode-vue-languageservice/src/types.ts
@@ -77,6 +77,7 @@ export type Modules = {
 };
 
 export type LanguageServiceContextBase = {
+	isVue2Mode: boolean,
 	modules: Modules,
 	htmlLs: html.LanguageService,
 	pugLs: pug.LanguageService,

--- a/packages/vscode-vue-languageservice/src/use/useSfcScriptGen.ts
+++ b/packages/vscode-vue-languageservice/src/use/useSfcScriptGen.ts
@@ -15,7 +15,7 @@ export function useSfcScriptGen(
 	vueDoc: Ref<TextDocument>,
 	script: Ref<IDescriptor['script']>,
 	scriptSetup: Ref<IDescriptor['scriptSetup']>,
-	html: Ref<string | undefined>,
+	sfcTemplateCompileResult: ReturnType<(typeof import('./useSfcTemplateCompileResult'))['useSfcTemplateCompileResult']>,
 ) {
 
 	let version = 0;
@@ -42,8 +42,8 @@ export function useSfcScriptGen(
 		)
 	);
 	const htmlGen = computed(() => {
-		if (html.value) {
-			return templateGen.generate(html.value);
+		if (sfcTemplateCompileResult.value?.ast) {
+			return templateGen.generate(sfcTemplateCompileResult.value.ast);
 		}
 	})
 	const suggestionCodeGen = computed(() =>

--- a/packages/vscode-vue-languageservice/src/use/useSfcTemplateCompileResult.ts
+++ b/packages/vscode-vue-languageservice/src/use/useSfcTemplateCompileResult.ts
@@ -2,10 +2,11 @@ import * as vscode from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { computed, Ref } from '@vue/reactivity';
 import * as CompilerDOM from '@vue/compiler-dom';
-// import * as CompilerVue2 from '../utils/vue2templateCompiler';
+import * as CompilerVue2 from '../utils/vue2templateCompiler';
 
 export function useSfcTemplateCompileResult(
 	htmlDocument: Ref<TextDocument | undefined>,
+	isVue2Mode: boolean,
 ) {
 	return computed(() => {
 
@@ -16,7 +17,7 @@ export function useSfcTemplateCompileResult(
 		let ast: CompilerDOM.RootNode | undefined;
 
 		try {
-			ast = CompilerDOM.compile(htmlDocument.value.getText(), {
+			ast = (isVue2Mode ? CompilerVue2 : CompilerDOM).compile(htmlDocument.value.getText(), {
 				onError: err => {
 					if (!err.loc) return;
 

--- a/packages/vscode-vue-languageservice/src/use/useSfcTemplateCompileResult.ts
+++ b/packages/vscode-vue-languageservice/src/use/useSfcTemplateCompileResult.ts
@@ -1,0 +1,56 @@
+import * as vscode from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { computed, Ref } from '@vue/reactivity';
+import * as CompilerDOM from '@vue/compiler-dom';
+// import * as CompilerVue2 from '../utils/vue2templateCompiler';
+
+export function useSfcTemplateCompileResult(
+	htmlDocument: Ref<TextDocument | undefined>,
+) {
+	return computed(() => {
+
+		if (!htmlDocument.value)
+			return;
+
+		const errors: vscode.Diagnostic[] = [];
+		let ast: CompilerDOM.RootNode | undefined;
+
+		try {
+			ast = CompilerDOM.compile(htmlDocument.value.getText(), {
+				onError: err => {
+					if (!err.loc) return;
+
+					const diagnostic: vscode.Diagnostic = {
+						range: {
+							start: htmlDocument.value!.positionAt(err.loc.start.offset),
+							end: htmlDocument.value!.positionAt(err.loc.end.offset),
+						},
+						severity: vscode.DiagnosticSeverity.Error,
+						code: err.code,
+						source: 'vue',
+						message: err.message,
+					};
+					errors.push(diagnostic);
+				},
+			}).ast;
+		}
+		catch (err) {
+			const diagnostic: vscode.Diagnostic = {
+				range: {
+					start: htmlDocument.value.positionAt(0),
+					end: htmlDocument.value.positionAt(htmlDocument.value.getText().length),
+				},
+				severity: vscode.DiagnosticSeverity.Error,
+				code: err.code,
+				source: 'vue',
+				message: err.message,
+			};
+			errors.push(diagnostic);
+		}
+
+		return {
+			errors,
+			ast,
+		};
+	});
+}

--- a/packages/vscode-vue-languageservice/src/use/useSfcTemplateCompileResult.ts
+++ b/packages/vscode-vue-languageservice/src/use/useSfcTemplateCompileResult.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { computed, Ref } from '@vue/reactivity';
 import * as CompilerDOM from '@vue/compiler-dom';
-import * as CompilerVue2 from '../utils/vue2templateCompiler';
+import * as CompilerVue2 from '../utils/vue2TemplateCompiler';
 
 export function useSfcTemplateCompileResult(
 	htmlDocument: Ref<TextDocument | undefined>,

--- a/packages/vscode-vue-languageservice/src/use/useSfcTemplateScript.ts
+++ b/packages/vscode-vue-languageservice/src/use/useSfcTemplateScript.ts
@@ -49,6 +49,7 @@ export function useSfcTemplateScript(
 		return templateGen.generate(
 			templateData.value.sourceLang,
 			sfcTemplateCompileResult.value.ast,
+			context.isVue2Mode,
 			templateScriptData.components,
 			[...cssScopedClasses.value.values()].map(map => [...map.keys()]).flat(),
 			templateData.value.htmlToTemplate,

--- a/packages/vscode-vue-languageservice/src/use/useSfcTemplateScript.ts
+++ b/packages/vscode-vue-languageservice/src/use/useSfcTemplateScript.ts
@@ -30,6 +30,7 @@ export function useSfcTemplateScript(
 		html: string,
 		htmlToTemplate: (start: number, end: number) => number | undefined,
 	} | undefined>,
+	sfcTemplateCompileResult: ReturnType<(typeof import('./useSfcTemplateCompileResult'))['useSfcTemplateCompileResult']>,
 	context: LanguageServiceContext,
 ) {
 	let version = 0;
@@ -39,12 +40,15 @@ export function useSfcTemplateScript(
 	const cssModuleClasses = computed(() => cssClasses.parse(context.modules.css, styleDocuments.value.filter(style => style.module), context));
 	const cssScopedClasses = computed(() => cssClasses.parse(context.modules.css, styleDocuments.value.filter(style => style.scoped), context));
 	const templateCodeGens = computed(() => {
+
 		if (!templateData.value)
+			return;
+		if (!sfcTemplateCompileResult.value?.ast)
 			return;
 
 		return templateGen.generate(
 			templateData.value.sourceLang,
-			templateData.value.html,
+			sfcTemplateCompileResult.value.ast,
 			templateScriptData.components,
 			[...cssScopedClasses.value.values()].map(map => [...map.keys()]).flat(),
 			templateData.value.htmlToTemplate,

--- a/packages/vscode-vue-languageservice/src/utils/vue2TemplateCompiler.ts
+++ b/packages/vscode-vue-languageservice/src/utils/vue2TemplateCompiler.ts
@@ -1,0 +1,60 @@
+import * as CompilerCore from '@vue/compiler-core';
+
+export function vue2Compile(
+	template: string,
+	options: CompilerCore.CompilerOptions = {}
+): CompilerCore.CodegenResult {
+
+	// force to vue 2
+	options.compatConfig = { MODE: 2 }
+
+	const onError = ((error: CompilerCore.CompilerError) => {
+		if (error.code === CompilerCore.ErrorCodes.X_V_FOR_TEMPLATE_KEY_PLACEMENT)
+			return // :key binding allow in v-for template child in vue 2
+		if (options.onError)
+			options.onError(error)
+		else
+			throw error
+	})
+	const isModuleMode = options.mode === 'module'
+
+	const prefixIdentifiers = options.prefixIdentifiers === true || isModuleMode
+	if (!prefixIdentifiers && options.cacheHandlers) {
+		onError(CompilerCore.createCompilerError(CompilerCore.ErrorCodes.X_CACHE_HANDLER_NOT_SUPPORTED))
+	}
+	if (options.scopeId && !isModuleMode) {
+		onError(CompilerCore.createCompilerError(CompilerCore.ErrorCodes.X_SCOPE_ID_NOT_SUPPORTED))
+	}
+
+	const ast = CompilerCore.baseParse(template, options)
+	const [nodeTransforms, directiveTransforms] = CompilerCore.getBaseTransformPreset(prefixIdentifiers)
+
+	// v-for > v-if in vue 2
+	const transformIf = nodeTransforms[1]
+	const transformFor = nodeTransforms[3]
+	nodeTransforms[1] = transformFor
+	nodeTransforms[3] = transformIf
+
+	CompilerCore.transform(
+		ast,
+		Object.assign({}, options, {
+			prefixIdentifiers,
+			nodeTransforms: [
+				...nodeTransforms,
+				...(options.nodeTransforms || []) // user transforms
+			],
+			directiveTransforms: Object.assign(
+				{},
+				directiveTransforms,
+				options.directiveTransforms || {} // user transforms
+			)
+		})
+	)
+
+	return CompilerCore.generate(
+		ast,
+		Object.assign({}, options, {
+			prefixIdentifiers
+		})
+	)
+}


### PR DESCRIPTION
Close #346

Support Vue 2 template by `experimentalCompatMode` option (may change in future):

```jsonc
// tsconfig.json
{
  "compilerOptions": {
    ...
  },
  "vueCompilerOptions": {
    "experimentalCompatMode": 2
  },
}
```