### PR TITLE
fix: Adjusting the position of "</template>" tags in CodeLens' "pug-to-html"

### DIFF
--- a/packages/vscode-vue-languageservice/src/commands/pugToHtml.ts
+++ b/packages/vscode-vue-languageservice/src/commands/pugToHtml.ts
@@ -10,7 +10,7 @@ export function execute(document: TextDocument, sourceFile: SourceFile, connecti
 	if (lang !== 'pug') return;
 
 	const html = pugToHtml(desc.template.content);
-	const newTemplate = `<template>\n` + html;
+	const newTemplate = `<template>\n` + html + `\n`;
 
 	let start = desc.template.loc.start - '<template>'.length;
 	const end = desc.template.loc.end;


### PR DESCRIPTION
## Description

I was curious about the position of the </template> tag in Code Lens' pug-to-html. (Of course, this is not a problem since you can use the formatting feature to fix it)

Adjusted by adding line breaks.

**volar version:** 

v0.26.15

## DEMO

### Before

https://user-images.githubusercontent.com/188642/129130092-b62b06af-2769-4230-9b13-d94cb6d73101.mp4

### After

https://user-images.githubusercontent.com/188642/129130108-1c8101c1-ea18-427c-991a-97d756da5c2d.mp4

## Notes

Of course, if there are any problems, you can close this Pull Request without Merge. 🙇