### PR TITLE
fix: useSetupSugar blocks order error (#378)

### DIFF
--- a/packages/vscode-vue-languageservice/src/commands/useSetupSugar.ts
+++ b/packages/vscode-vue-languageservice/src/commands/useSetupSugar.ts
@@ -92,15 +92,12 @@ export function register(context: ApiLanguageServiceContext) {
 			const newScriptCode = getScriptCode();
 
 			let newBlockCode = '\n' + newScriptSetupCode + '\n';
+			addReplace(0, _script.content.length, newBlockCode);
 
 			if (newScriptCode !== '') {
-				newBlockCode += '</script>\n';
-				newBlockCode += '\n';
-				newBlockCode += startTagText + '\n';
-				newBlockCode += newScriptCode + '\n';
+				let newScriptBlock = `${startTagText}\n${newScriptCode}\n</script>\n\n`
+				addReplace(-startTagText.length, -startTagText.length, newScriptBlock)
 			}
-
-			addReplace(0, _script.content.length, newBlockCode);
 
 			return edits;
 

--- a/packages/vscode-vue-languageservice/src/commands/useSetupSugar.ts
+++ b/packages/vscode-vue-languageservice/src/commands/useSetupSugar.ts
@@ -91,12 +91,11 @@ export function register(context: ApiLanguageServiceContext) {
 			const newScriptSetupCode = getScriptSetupCode();
 			const newScriptCode = getScriptCode();
 
-			let newBlockCode = '\n' + newScriptSetupCode + '\n';
-			addReplace(0, _script.content.length, newBlockCode);
+			addReplace(0, _script.content.length, '\n' + newScriptSetupCode + '\n');
 
 			if (newScriptCode !== '') {
-				let newScriptBlock = `${startTagText}\n${newScriptCode}\n</script>\n\n`
-				addReplace(-startTagText.length, -startTagText.length, newScriptBlock)
+				let newScriptBlock = `${startTagText}\n${newScriptCode}\n</script>\n\n`;
+				addReplace(-startTagText.length, -startTagText.length, newScriptBlock);
 			}
 
 			return edits;


### PR DESCRIPTION
Adjusted the code block insertion order generated by useSetupSugar. Now the block like `<script setup>` is below the `<script>`