### PR TITLE
[proof of concept] Make typescript optional in initializationOptions

### DIFF
--- a/packages/server/src/servicesManager.ts
+++ b/packages/server/src/servicesManager.ts
@@ -9,7 +9,7 @@ export type ServicesManager = ReturnType<typeof createServicesManager>;
 
 export function createServicesManager(
 	options: shared.ServerInitializationOptions,
-	getTs: () => {
+	loadedTs: {
 		server: typeof import('typescript/lib/tsserverlibrary'),
 		localized: ts.MapLike<string> | undefined,
 	},
@@ -19,7 +19,7 @@ export function createServicesManager(
 ) {
 
 	let filesUpdateTrigger = false;
-	const originalTs = getTs().server;
+	const originalTs = loadedTs.server;
 	const tsConfigNames = ['tsconfig.json', 'jsconfig.json'];
 	const tsConfigWatchers = new Map<string, ts.FileWatcher>();
 	const services = new Map<string, ServiceHandler>();
@@ -162,9 +162,8 @@ export function createServicesManager(
 			tsConfigWatchers.get(tsConfig)?.close();
 			services.delete(tsConfig);
 		}
-		const _ts = getTs();
-		const ts = _ts.server;
-		const tsLocalized = _ts.localized;
+		const ts = loadedTs.server;
+		const tsLocalized = loadedTs.localized;
 		if (ts.sys.fileExists(tsConfig)) {
 			services.set(tsConfig, createServiceHandler(
 				ts,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,15 +1,20 @@
-import type * as Requests from './requests';
+.import type * as Requests from './requests';
 
 export declare let __requests: typeof Requests; // keep this code for jsdoc link
 
 export interface ServerInitializationOptions {
-	typescript: {
+	/**
+	 * If this option is null, Volar will try to:
+	 * 1. Use tsserver in node_modules of the workspace root.
+	 * 2. Use bundled tsserver in node_modules of a Volar extension.
+	 */
+	typescript?: {
 		/**
 		 * Path of tsserverlibrary.js / tsserver.js / typescript.js
 		 */
 		serverPath: string
 		localizedPath: string | undefined
-	}
+	} | undefined
 	/**
 	 * typescript, html, css... language service will be create in server if this option is not null
 	 */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,4 +1,4 @@
-.import type * as Requests from './requests';
+import type * as Requests from './requests';
 
 export declare let __requests: typeof Requests; // keep this code for jsdoc link
 


### PR DESCRIPTION
> Note: This is a proof of concept. This PR is just meant to give some ideas, 
so feel free to push commits to this PR or create a new PR that is better. :)

This PR makes the `typescript` option optional in `initializationOptions`. 

**Why?**
Each lsp clients need to reinvent the way of how to find tsserver path. 
By moving that logic to the server, clients can get rid of that code.
Of course someone can still pass in the tsserver path in the `initializationOptions` if there is a need for that. (this change should be backwards compatible)

Inspiration taken from theia-typescript-server: 
https://github.com/typescript-language-server/typescript-language-server/blob/3c457111969899d7cd72291db1e6dddb5ac68cf6/src/lsp-server.ts#L68

Except that theia-typescript-server is more bullet proof, and it will try to:
- load tsserver if yarn pnp is used
- else load tsserver in workspace folder
- else load the globally installed tsserver
- else load tsserver bundled with a extension

This PR only adds:
- load tsserver in workspace folder
- else load tsserver bundled with a extension