### PR TITLE
fix: support isRefType for @vue/composition-api, close #404

### DIFF
--- a/packages/vscode-vue-languageservice/src/services/refAutoClose.ts
+++ b/packages/vscode-vue-languageservice/src/services/refAutoClose.ts
@@ -84,7 +84,7 @@ export function isRefType(typeDefs: vscode.LocationLink[], tsLs: ts2.LanguageSer
 	for (const typeDefine of typeDefs) {
 		const uri = vscode.Location.is(typeDefine) ? typeDefine.uri : typeDefine.targetUri;
 		const range = vscode.Location.is(typeDefine) ? typeDefine.range : typeDefine.targetSelectionRange;
-		if (uri.endsWith('reactivity.d.ts')) {
+		if (uri.endsWith('reactivity.d.ts') || uri.endsWith('vue-composition-api.d.ts')) {
 			const defineDoc = tsLs.__internal__.getTextDocument(uri);
 			if (!defineDoc)
 				continue;


### PR DESCRIPTION
Not sure if it's the fix, just browse the code and thought this might be the point (not tested). Feel free to close if it's wrong.

`@vue/composition-api` use `dist/index.d.ts` for the file name, and I have changed it to `dist/vue-composition-api.d.ts` since v1.1.3 for this.