### PR TITLE
fix: incorrect logic of `translateDiagnosticRelated`

### DIFF
--- a/packages/vscode-typescript-languageservice/src/services/diagnostics.ts
+++ b/packages/vscode-typescript-languageservice/src/services/diagnostics.ts
@@ -76,8 +76,8 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 		}
 		function translateDiagnosticRelated(diag: ts.Diagnostic): vscode.DiagnosticRelatedInformation | undefined {
 
-			if (!diag.start) return;
-			if (!diag.length) return;
+			if (diag.start === undefined) return;
+			if (diag.length === undefined) return;
 
 			let document: TextDocument | undefined;
 			if (diag.file) {

--- a/packages/vscode-typescript-languageservice/src/services/diagnostics.ts
+++ b/packages/vscode-typescript-languageservice/src/services/diagnostics.ts
@@ -44,8 +44,8 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 		}
 		function translateDiagnostic(diag: ts.Diagnostic, document: TextDocument): vscode.Diagnostic | undefined {
 
-			if (!diag.start) return;
-			if (!diag.length) return;
+			if (diag.start === undefined) return;
+			if (diag.length === undefined) return;
 
 			const diagnostic: vscode.Diagnostic = {
 				range: {


### PR DESCRIPTION
In TypeScript or JavaScript file

![image](https://user-images.githubusercontent.com/31695475/134704859-4dfb8cab-6ac7-4f50-9e9e-fb9eeef2bb54.png)

Volar

![image](https://user-images.githubusercontent.com/31695475/134704933-90f1c3b0-549f-4b2d-8675-1397fb945250.png)
