### PR TITLE
Improve v-for type

### DIFF
--- a/packages/vscode-vue-languageservice/src/generators/template.ts
+++ b/packages/vscode-vue-languageservice/src/generators/template.ts
@@ -105,7 +105,7 @@ export function generate(
 		tsCodeGen.addText(`declare const ${var_slotsComponent}: __VLS_SlotsComponent<typeof ${var_rawComponent}>;\n`);
 		tsCodeGen.addText(`declare const ${var_baseProps}: __VLS_ExtractComponentProps<typeof ${var_rawComponent}>;\n`);
 		tsCodeGen.addText(`declare const ${var_emit}: __VLS_ExtractEmit2<typeof ${var_rawComponent}>;\n`);
-		tsCodeGen.addText(`declare const ${var_slots}: 
+		tsCodeGen.addText(`declare const ${var_slots}:
 			__VLS_TemplateSlots<typeof ${var_wrapComponent}>
 			& __VLS_DefaultSlots<typeof ${var_wrapComponent}, typeof ${var_rawComponent}>;\n`);
 
@@ -579,7 +579,7 @@ export function generate(
 					},
 					formatBrackets.empty,
 				);
-				tsCodeGen.addText(` = __VLS_pickForItem(${sourceVarName}, ${sourceVarName}[__VLS_getVforKeyType(${sourceVarName})]);\n`);
+				tsCodeGen.addText(` = __VLS_pickForItem(${sourceVarName});\n`);
 
 				if (key && key.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
 					let start_key = key.loc.start.offset;

--- a/packages/vscode-vue-languageservice/src/utils/globalDoc.ts
+++ b/packages/vscode-vue-languageservice/src/utils/globalDoc.ts
@@ -70,7 +70,7 @@ declare global {
 	function __VLS_getVforKeyType<T>(source: T): typeof Symbol.iterator extends keyof T ? number : keyof T;
 	function __VLS_getVforIndexType<T>(source: T): typeof Symbol.iterator extends keyof T ? undefined : number;
 	function __VLS_getNameOption<T>(t?: T): T extends { name: infer N } ? N : undefined;
-	function __VLS_pickForItem<S, T2>(source: S, forInItem: T2): S extends { [Symbol.iterator](): IterableIterator<infer T1> } ? T1 : T2;
+	function __VLS_pickForItem<T>(source: T): T extends { [Symbol.iterator](): IterableIterator<infer T1> } ? T1 : T[keyof T];
 	function __VLS_mergePropDefaults<P, D>(props: P, defaults: D): {
 		[K in keyof P]: K extends keyof D ? P[K] & {
 			default: D[K]

--- a/packages/vscode-vue-languageservice/src/utils/globalDoc.ts
+++ b/packages/vscode-vue-languageservice/src/utils/globalDoc.ts
@@ -67,7 +67,7 @@ declare global {
 	interface __VLS_GlobalComponents extends GlobalComponents { }
 	var __VLS_defineComponent: PickNotAny<typeof vue_1.defineComponent, typeof vue_2.defineComponent>;
 	function __VLS_getVforSourceType<T>(source: T): T extends number ? number[] : T;
-	function __VLS_getVforKeyType<T>(source: T): typeof Symbol.iterator extends keyof T ? number : keyof T;
+	function __VLS_getVforKeyType<T>(source: T): typeof Symbol.iterator extends keyof T ? number : T extends T ? keyof T : never;
 	function __VLS_getVforIndexType<T>(source: T): typeof Symbol.iterator extends keyof T ? undefined : number;
 	function __VLS_getNameOption<T>(t?: T): T extends { name: infer N } ? N : undefined;
 	function __VLS_pickForItem<T>(source: T): T extends { [Symbol.iterator](): IterableIterator<infer T1> } ? T1 : T[keyof T];

--- a/packages/vscode-vue-languageservice/src/utils/globalDoc.ts
+++ b/packages/vscode-vue-languageservice/src/utils/globalDoc.ts
@@ -67,7 +67,7 @@ declare global {
 	interface __VLS_GlobalComponents extends GlobalComponents { }
 	var __VLS_defineComponent: PickNotAny<typeof vue_1.defineComponent, typeof vue_2.defineComponent>;
 	function __VLS_getVforSourceType<T>(source: T): T extends number ? number[] : T;
-	function __VLS_getVforKeyType<T>(source: T): typeof Symbol.iterator extends keyof T ? number : T extends T ? keyof T : never;
+	function __VLS_getVforKeyType<T>(source: T): typeof Symbol.iterator extends keyof T ? number : T extends T ? keyof T : never; // use "T extends T" support for union
 	function __VLS_getVforIndexType<T>(source: T): typeof Symbol.iterator extends keyof T ? undefined : number;
 	function __VLS_getNameOption<T>(t?: T): T extends { name: infer N } ? N : undefined;
 	function __VLS_pickForItem<T>(source: T): T extends { [Symbol.iterator](): IterableIterator<infer T1> } ? T1 : T[keyof T];

--- a/packages/vscode-vue-languageservice/testCases/tsconfig.json
+++ b/packages/vscode-vue-languageservice/testCases/tsconfig.json
@@ -2,5 +2,6 @@
     "compilerOptions": {
         "strict": true,
         "allowJs": true,
+        "noUncheckedIndexedAccess": true
     }
 }

--- a/packages/vscode-vue-languageservice/testCases/typeChecks/v_for.vue
+++ b/packages/vscode-vue-languageservice/testCases/typeChecks/v_for.vue
@@ -1,0 +1,58 @@
+<template>
+  <!-- array -->
+  <div v-for="(val, key) in arr">
+    {{ exactType(val, expected as 'a' | 'b') }}
+    {{ isNotAnyOrUndefined(val) }}
+    {{ exactType(key, expected as number) }}
+    {{ isNotAnyOrUndefined(key) }}
+  </div>
+  <!-- map -->
+  <div v-for="(val, key) in map">
+    {{ exactType(val, expected as [string, number]) }}
+    {{ isNotAnyOrUndefined(val) }}
+    {{ exactType(key, expected as number) }}
+    {{ isNotAnyOrUndefined(key) }}
+  </div>
+  <!-- obj -->
+  <div v-for="(val, key) in obj">
+    {{ exactType(val, expected as string | number) }}
+    {{ isNotAnyOrUndefined(val) }}
+    {{ exactType(key, expected as 'a' | 'b') }}
+    {{ isNotAnyOrUndefined(key) }}
+  </div>
+  <!-- objUnion -->
+  <div v-for="(val, key) in objUnion">
+    {{ exactType(val, expected as string | number) }}
+    {{ isNotAnyOrUndefined(val) }}
+    {{ exactType(key, expected as 'a' | 'b') }}
+    {{ isNotAnyOrUndefined(key) }}
+  </div>
+  <!-- record -->
+  <div v-for="(val, key) in record">
+    {{ exactType(val, expected as string) }}
+    {{ isNotAnyOrUndefined(val) }}
+    {{ exactType(key, expected as string) }}
+    {{ isNotAnyOrUndefined(key) }}
+  </div>
+</template>
+
+<script lang="ts" setup>
+const arr = ['a', 'b'] as const
+const map = new Map<string, number>()
+const obj = { a: '', b: 0 }
+const objUnion = { a: '' } as { a: string } | { a:string, b: number }
+const record: Record<string, string> = { a: '' }
+
+declare const expected: any
+
+// https://stackoverflow.com/a/53808212
+type IfEquals<T, U, Y=unknown, N=never> =
+  (<G>() => G extends T ? 1 : 2) extends
+  (<G>() => G extends U ? 1 : 2) ? Y : N;
+declare function exactType<T, U>(draft: T & IfEquals<T, U>, expected: U & IfEquals<T, U>): IfEquals<T, U>
+
+// https://stackoverflow.com/a/49928360
+type IfNotAny<T> = 0 extends 1 & T ? never : T
+type IfNotUndefined<T> = Exclude<T, undefined> extends never ? never : T
+declare function isNotAnyOrUndefined<T>(value: IfNotAny<IfNotUndefined<T>>): void
+</script>

--- a/packages/vscode-vue-languageservice/tests/index.spec.ts
+++ b/packages/vscode-vue-languageservice/tests/index.spec.ts
@@ -10,3 +10,4 @@ import './renames/scriptSetup_element';
 import './renames/scriptSetup';
 
 import './typeChecks/emit';
+import './typeChecks/v_for';

--- a/packages/vscode-vue-languageservice/tests/typeChecks/v_for.ts
+++ b/packages/vscode-vue-languageservice/tests/typeChecks/v_for.ts
@@ -1,0 +1,4 @@
+import * as path from 'upath';
+import { defineTypeCheck } from '../utils/defineTypeCheck';
+
+defineTypeCheck(path.resolve(__dirname, '../../testCases/typeChecks/v_for.vue'), []);


### PR DESCRIPTION
Improved some types and added some tests.

---

Now v-for is transformed into the code below.
```ts
// when noUncheckedIndexedAccess: true
declare const record: Record<string, string>

declare function __VLS_getVforSourceType<T>(source: T): T extends number ? number[] : T;
declare function __VLS_getVforKeyType<T>(source: T): typeof Symbol.iterator extends keyof T ? number : keyof T;
declare function __VLS_getVforIndexType<T>(source: T): typeof Symbol.iterator extends keyof T ? undefined : number;
declare function __VLS_pickForItem<S, T2>(source: S, forInItem: T2): S extends { [Symbol.iterator](): IterableIterator<infer T1> } ? T1 : T2;

const __VLS_11 = __VLS_getVforSourceType(record) // Record<string, string>
for (const __VLS_12 in __VLS_11) {
    const val = __VLS_pickForItem(__VLS_11, __VLS_11[__VLS_getVforKeyType(__VLS_11)]) // string | undefined
    const key = __VLS_getVforKeyType(__VLS_11) // string
}
```
But `val` should not have `undefined` since it is not a index access.

So I changed the transformed result to be like below.
```ts
declare function __VLS_getVforKeyTypeNew<T>(source: T): typeof Symbol.iterator extends keyof T ? number : T extends T ? keyof T : never;
declare function __VLS_pickForItemNew<T>(source: T): T extends { [Symbol.iterator](): IterableIterator<infer T1> } ? T1 : T[keyof T];

const __VLS_21 = __VLS_getVforSourceType(record) // Record<string, string>
for (const __VLS_22 in __VLS_21) {
    const val = __VLS_pickForItemNew(__VLS_21) // string
    const key = __VLS_getVforKeyTypeNew(__VLS_21) // string
}
```
(`__VLS_getVforKeyTypeNew` does not effect this but I will explain the benefits below.)

---

While changing this, it affected some other patterns.
These are some examples.
```ts
declare const record: Record<string, string> // which I explained above
__VLS_pickForItem(record, record[__VLS_getVforKeyType(record)]) // string | undefined
__VLS_pickForItemNew(record) // string

declare const arr: ['a', 'b'] // no change
__VLS_pickForItem(arr, arr[__VLS_getVforKeyType(arr)]) // 'a' | 'b'
__VLS_pickForItemNew(arr) // 'a' | 'b'

declare const map: Map<string, number> // removed a error
__VLS_pickForItem(map, map[__VLS_getVforKeyType(map)]) // [string, number] with type error
__VLS_pickForItemNew(map) // [string, number]

declare const obj: { a: string, b: number } // no change
__VLS_pickForItem(obj, obj[__VLS_getVforKeyType(obj)]) // string | number
__VLS_pickForItemNew(obj) // string | number

declare const objUnion: { a: string } | { a: string, b: number } // better type, key should behave same so I changed __VLS_getVforKeyType
__VLS_pickForItem(objUnion, objUnion[__VLS_getVforKeyType(objUnion)]) // string
__VLS_pickForItemNew(objUnion) // string | number
__VLS_getVforKeyType(objUnion) // 'a'
__VLS_getVforKeyTypeNew(objUnion) // 'a' | 'b'
// https://stackoverflow.com/a/49402091
```

[TS Playground](https://www.typescriptlang.org/play?noUncheckedIndexedAccess=true&target=8&jsx=0#code/PTAEDsHsFVwYwBYFM4GskBMCS4NIB6YCCccSAzuQFygAuATgK5IBQLecANgIb1KhxI4crVB9B9DDQBKKSJIA8I+gEtwAcwA0oZWvUA+NiFABaM2YiQA7qfMm2HHn1AAzRvFoqhoAPo+AagAyAMo+6ki0-i7ywZCM9GQAKgCeAA5ICon6ABTkcQlINIkAlEWgBLRIuOQQjAC2AEZI9KAA-LWNzQDaALqgRQDc7ChO-G4eXuC+ASFhEVHyANJIySnpmTl58WRFpXRpSJAuoMHJjZCcAHQqlfTctPLl+JXVoOjJR6CJbR1NLTTvT6JIaOXhjdxwTzePxBULhSLReg4PD4NYZLK5fI7L57WgHT6nc5XG7Ne6PCpVDA1QHHb7tdx4FxqTD9X7NEEjMGuCFQqYw2apFRoABi8iwlTqCmC2kSACZNljCidtIicOKkHUirK9sEni8qaAAN6gLqEhoXa63Mn0HrZPbqu4NThIB3WhRqFzNL4ARn0oAAvj9Et7WXKhixBMJRPzQt6QwBeaawuYImKKtHZcTyDDFUDGWQSDBKBh6bS6DSGRGgbKRkRJ2be2WgNT12Pe3OGligbsCIR1gBu3E4oETMZ8gpFYol2THce0s+9XTH8IW9GWqwOM5mbeKPVzxnL6lAAB9QAykEzwJguz3a6J3iPWynV+uMwv92BDyx-UYwHYTAICDcBo-APLY5gOJyzjjJCkxPiuiKvgcABySBWBsmLbEqJQ0Hi6QEmc5rElaDwtBSrw0l8PzgPUfyhnqlI1HSbwrECrJXv27LDFwXIwbyT4TqgopIhKqHoRiWwFLsZTkQaxqmoRFokncpG2vaVpOi6JHyO64Cei0wZ+oG7TBqGXSUYkPThneT6ygm8HzIisRYRmWaSB+oAFtmxaqBoZYlhWLBVjWfbRtuPiyk2LZjnZHY3t2NmDsOo7hYJwnqnUYlbsmsV5p+AXqPFvZRixySPsujlLCsaJZTF7Z5ToBXfr+4EWAQ3B1Kkzo1P+kE8c4Nm8PQNBdAA5Nwo3aKNDSjT03GjMVdZ1NwqQ0AAsitPmlmy9CGKCA2haAkANAAVjQxrcDQh7aA0NA0Z0LQ-vt-A2cdJ2wJM52gJdjW+UeganhdV0FTdd20V6P4sGOaVThqWVuTmDVftDQpCbDmVodkQ0eeNo0nqA02jVDqWo+lomY8tqQeV0107XNKOTiJcOY29HmHvj91-MTyYw0zGNWNkb0fUIbMFRz4P0GwDNo3zmZyJI2gI0u4UIVVG7pHLha7qLf34+el7XtLZMalj9D0NoQ3K8mqtrtVm7Y3uDW4-jhPcwKpPo9klPaJTVuzDbSEa5T2sNTTIN06AVg3Ag+zpOUZvyG7oS8xlgundob1+3ClW2+rSBpydIcHmLp6c80Sfjh7stC+AkwZ6dwvgFnz6IXbGs15MRf5X9bAVwHbf5x3ItOxNfc54HSBZUP4A4xNLszSwQA)
