### PR TITLE
VSCode Vue Language Service: Check the template lang before assuming sourceLang is 'html'

### DIFF
--- a/packages/vscode-vue-languageservice/src/sourceFile.ts
+++ b/packages/vscode-vue-languageservice/src/sourceFile.ts
@@ -80,7 +80,7 @@ export function createSourceFile(
 				},
 			};
 		}
-		if (descriptor.template && sfcTemplate.textDocument.value) {
+		if (descriptor.template && sfcTemplate.textDocument.value && descriptor.template.lang === 'html') {
 			return {
 				sourceLang: 'html',
 				html: descriptor.template.content,


### PR DESCRIPTION
This fixes the issue where the SFC template is not Pug or HTML: `vscode-vue-languageservice` incorrectly assumes that the SFC template has `HTML` lang.