### PR TITLE
Fix TypeError that can occur in non-VSCode clients

### DIFF
--- a/packages/vscode-vue-languageservice/src/services/hover.ts
+++ b/packages/vscode-vue-languageservice/src/services/hover.ts
@@ -104,7 +104,7 @@ export function register({ sourceFiles, htmlLs, pugLs, getCssLs, getTsLs, vueHos
 						sourceMap.mappedDocument,
 						htmlRange.start,
 						sourceMap.htmlDocument,
-						settings ?? {}
+						settings,
 					)
 					: pugLs.doHover(
 						sourceMap.pugDocument,

--- a/packages/vscode-vue-languageservice/src/services/hover.ts
+++ b/packages/vscode-vue-languageservice/src/services/hover.ts
@@ -104,7 +104,7 @@ export function register({ sourceFiles, htmlLs, pugLs, getCssLs, getTsLs, vueHos
 						sourceMap.mappedDocument,
 						htmlRange.start,
 						sourceMap.htmlDocument,
-						settings
+						settings ?? {}
 					)
 					: pugLs.doHover(
 						sourceMap.pugDocument,


### PR DESCRIPTION
When trying to use `@volar/server` in non-VSCode clients (in my case, Emacs' [eglot](https://github.com/joaotavora/eglot)), hovering over a HTML tag in the `<template>` section causes the server to error with `TypeError: Cannot read property 'documentation' of null`. The reason for this is that `connection.workspace.getConfiguration` returns `null` when the client doesn't have a response for the given section in `workspace/configuration`, and so [getHtmlHoverSettings](https://github.com/johnsoncodehk/volar/blob/eb2d8e4f40c3e8a2df5e855bc298ccafbe721f05/packages/server/src/configs.ts#L39) returns `null` when `htmlLs.doHover` used [here](https://github.com/johnsoncodehk/volar/blob/master/packages/vscode-vue-languageservice/src/services/hover.ts#L107) expects `undefined` or an object.

Since not all LSP clients will define `html.hover` in their workspace configurations, this PR fixes this issue by supplying `htmlLs.doHover` with an empty object if it is not defined.