### PR TITLE
fix: resolve dependency issues

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,12 +14,12 @@
 	},
 	"dependencies": {
 		"upath": "^2.0.1",
+		"vscode-html-languageservice": "^4.2.1",
 		"vscode-jsonrpc": "^8.0.0-next.4",
 		"vscode-uri": "^3.0.2"
 	},
 	"devDependencies": {
 		"typescript": "latest",
-		"vscode-html-languageservice": "^4.2.1",
 		"vscode-languageserver-protocol": "^3.17.0-next.11",
 		"vscode-languageserver-textdocument": "^1.0.3"
 	}

--- a/packages/vue-tsc/bin/vue-tsc.js
+++ b/packages/vue-tsc/bin/vue-tsc.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 
 const readFileSync = fs.readFileSync;
 const tscPath = require.resolve('typescript/lib/tsc');
+const proxyPath = JSON.stringify(require.resolve('../out/proxy'));
 
 fs.readFileSync = (...args) => {
     if (args[0] === tscPath) {
@@ -17,7 +18,7 @@ fs.readFileSync = (...args) => {
         );
         tsc = tsc.replace(
             `function createProgram(rootNamesOrOptions, _options, _host, _oldProgram, _configFileParsingDiagnostics) {`,
-            `function createProgram(rootNamesOrOptions, _options, _host, _oldProgram, _configFileParsingDiagnostics) { return require('vue-tsc/out/proxy').createProgramProxy(...arguments);`,
+            `function createProgram(rootNamesOrOptions, _options, _host, _oldProgram, _configFileParsingDiagnostics) { return require(${proxyPath}).createProgramProxy(...arguments);`,
         );
         return tsc;
     }


### PR DESCRIPTION
**What's the problem this PR addresses?**

- `@volar/shared` depends on `vscode-html-languageservice` but doesn't declare it as a dependency.
- The patch that `vue-tsc` applies to `tsc` doesn't pre-resolve the path to the proxy which makes it rely on hoisting to place `typescript` and `vue-tsc` next to each other which isn't guaranteed to happen.

**How did you fix it?**

- Move `vscode-html-languageservice` from `devDependencies` to `dependencies`.
- Inject the absolute path to the proxy instead of an identifier.