### PR TITLE
fix(schemas): missing "vue-jsconfig.schema.json"

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -116,7 +116,7 @@
 			},
 			{
 				"fileMatch": "jsconfig.json",
-				"url": "./schemas/vue-jsconfig.schema.json"
+				"url": "./schemas/vue-tsconfig.schema.json"
 			},
 			{
 				"fileMatch": "jsconfig.*.json",
@@ -128,7 +128,7 @@
 			},
 			{
 				"fileMatch": "jsconfig.*.json",
-				"url": "./schemas/vue-jsconfig.schema.json"
+				"url": "./schemas/vue-tsconfig.schema.json"
 			}
 		],
 		"languages": [


### PR DESCRIPTION
It seems that `vue-jsconfig.schema.json` does not exist in the schemas directory. When editing `jsconfig.json`, the json language server will output an error.

<img width="719" alt="fix-volar-vue-jsconfig-schemas" src="https://user-images.githubusercontent.com/188642/149700432-1a388802-31c7-4f2f-b0a7-ef287b7225e9.png">

Changed `jsconfig.json` related "jsonValidation" to `vue-tsconfig.schema.json`.

