### PR TITLE
docs: suggest snippets from the VSCode Marketplace

### DIFF
--- a/extensions/vscode-vue-language-features/README.md
+++ b/extensions/vscode-vue-language-features/README.md
@@ -117,7 +117,7 @@ export {}
 
 > Volar does not include ESLint and Prettier, but the official [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) and [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extensions support Vue, so you could install these yourself if needed.
 
-> If using Vetur's [Customizable Scaffold Snippets](https://vuejs.github.io/vetur/guide/snippet.html#customizable-scaffold-snippets), recommend use [Snippet Generator](https://marketplace.visualstudio.com/items?itemName=wenfangdu.snippet-generator) convert to VSCode Snippets.
+> If using Vetur's [Customizable Scaffold Snippets](https://vuejs.github.io/vetur/guide/snippet.html#customizable-scaffold-snippets), recommend use [Snippet Generator](https://marketplace.visualstudio.com/items?itemName=wenfangdu.snippet-generator) convert to VSCode Snippets. There are also snippets on the VSCode Marketplace, such as Sarah Drasner's [Vue VSCode Snippets](https://marketplace.visualstudio.com/items?itemName=sdras.vue-vscode-snippets), if you prefer ready-made snippets without customization.
 
 > If VSCode gives an error for `class` and `slot` like this:
 > 


### PR DESCRIPTION
Hi, I'd like to propose a tiny addition to the docs if you're accepting.

I think this would be helpful to folks migrating over to Volar from Vetur who, like myself, don't really care about customizing their snippets, but just want some quick, ready-made snippets they can install with a click. Sarah Drasner's snippets are relatively popular, with Vue 3 support, and she's a member of Vue's core team so I suspect they will be well maintained. I read through #183 and #781 and appreciate the rationale not to include built-in snippets, but this seems like an easy alternative.

Happy to amend or close if you're not accepting PR's of this sort. Thanks!