### PR TITLE
chore: add "-" to the html completion trigger characters

### DIFF
--- a/packages/vscode-vue-languageservice/src/services/completion.ts
+++ b/packages/vscode-vue-languageservice/src/services/completion.ts
@@ -21,7 +21,7 @@ export function getTriggerCharacters(tsVersion: string) {
 	return {
 		typescript: ts2.getTriggerCharacters(tsVersion),
 		jsdoc: ['*'],
-		html: ['.', ':', '<', '"', '=', '/'], // https://github.com/microsoft/vscode/blob/09850876e652688fb142e2e19fd00fd38c0bc4ba/extensions/html-language-features/server/src/htmlServer.ts#L183
+		html: ['.', ':', '<', '"', '=', '/', '-'], // https://github.com/microsoft/vscode/blob/09850876e652688fb142e2e19fd00fd38c0bc4ba/extensions/html-language-features/server/src/htmlServer.ts#L183
 		css: ['/', '-', ':'], // https://github.com/microsoft/vscode/blob/09850876e652688fb142e2e19fd00fd38c0bc4ba/extensions/css-language-features/server/src/cssServer.ts#L97
 		json: ['"', ':'], // https://github.com/microsoft/vscode/blob/09850876e652688fb142e2e19fd00fd38c0bc4ba/extensions/json-language-features/server/src/jsonServer.ts#L150
 	};


### PR DESCRIPTION
In "coc-volar", starting from `v0.30.2` of `@volar/server`, typing `-` in `<template>` causes completion to be canceled...

- **REF**: <https://github.com/yaegassy/coc-volar/issues/110>

I considered making adjustments on the `coc-volar` side, but that would have led to other problems, so I made adjustments on the language server side.

If adding `-` causes problems, don't worry about it, just close this PR. 🙇
