### PR TITLE
fix: globalProperties not ShallowUnwrapRef on the template

### DIFF
--- a/packages/vscode-vue-languageservice/src/utils/localTypes.ts
+++ b/packages/vscode-vue-languageservice/src/utils/localTypes.ts
@@ -94,7 +94,7 @@ export type ExtractComponentProps<T> =
 	: T extends FunctionalComponent<infer P2> ? P2
 	: T
 
-export type ExtractRawComponents<T> = { [K in keyof T]: ExtractRawComponent<T[K]> };
+export type ExtractRawComponents<T> = vue.ShallowUnwrapRef<{ [K in keyof T]: ExtractRawComponent<T[K]> }>;
 export type ExtractRawComponent<T> = T extends { __VLS_raw: infer C } ? C : T;
 export type ExtractEmit2<T> =
 	T extends FunctionalComponent<infer _, infer E> ? SetupContext<E>['emit']


### PR DESCRIPTION
fix #954

This will shallow unwrap the `__VLS_ctx` type