### PR TITLE
fix: use `console.warn` instead of `console.log`

### DIFF
--- a/packages/shared/src/ts.ts
+++ b/packages/shared/src/ts.ts
@@ -139,7 +139,7 @@ function resolveVueCompilerOptions(rawOptions: {
 		try {
 			result.experimentalTemplateCompilerOptions = require(templateOptionsPath).default;
 		} catch (error) {
-			console.log('Failed to require "experimentalTemplateCompilerOptionsRequirePath":', templateOptionsPath);
+			console.warn('Failed to require "experimentalTemplateCompilerOptionsRequirePath":', templateOptionsPath);
 			console.error(error);
 		}
 	}

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -516,7 +516,7 @@ export function loadCustomPlugins(dir: string) {
 		return config.plugins ?? []
 	}
 	catch (err) {
-		console.log('load volar.config.js failed in', dir);
+		console.warn('load volar.config.js failed in', dir);
 		return [];
 	}
 }


### PR DESCRIPTION
fix #1043 

This PR replaces `console.log` to `console.warn` where their output affects to LSP clients.