### PR TITLE
fix(code-gen): support attribute binding syntax `:<name>.attr`

### DIFF
--- a/packages/vue-code-gen/src/generators/template.ts
+++ b/packages/vue-code-gen/src/generators/template.ts
@@ -393,8 +393,8 @@ export function generate(
 						? prop.arg.content
 						: prop.arg.loc.source
 
-					if (prop.modifiers.some(m => m === 'prop')) {
-						propName = propName.substr(1);
+					if (prop.modifiers.some(m => m === 'prop' || m === 'attr')) {
+						propName = propName.substring(1);
 					}
 
 					if (prop.name === 'bind' || prop.name === 'model') {
@@ -858,8 +858,8 @@ export function generate(
 							: prop.arg.loc.source
 						: getModelValuePropName(node, isVue2);
 
-				if (prop.modifiers.some(m => m === 'prop')) {
-					propName_1 = propName_1.substr(1);
+				if (prop.modifiers.some(m => m === 'prop' || m === 'attr')) {
+					propName_1 = propName_1.substring(1);
 				}
 
 				const propName_2 = !isStatic ? propName_1 : hyphenate(propName_1) === propName_1 ? camelize(propName_1) : propName_1;


### PR DESCRIPTION
### Summary

Added missing support for attribute binding syntax `:<name>.attr`.  Reference https://vuejs.org/api/built-in-directives.html#v-bind

For example
```
<div :someProperty.attr="someString"></div>
```

related to #992 

The other way of binding attribute
```
<div ^someProperty="someString"></div>
```
I don't know how to fix yet. When debugging, `prop.type` for this syntax is `CompilerDOM.NodeTypes.ATTRIBUTE` while the above syntax is `CompilerDOM.NodeTypes.DIRECTIVE`. Not sure if that is Vue SFC compiler issue or not. 

IMO, since both syntaxes are equivalent, their `prop.type` should be the same. Probably you have more insight with Vue team about that.

### Test plan

- Pick up any projects using `vue-tsc`
- Create a SFC file with attribute binding syntax `:<name>.attr` in HTML part
- Run `vue-tsc` against that SFC file and verify if no error occurs.