### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/extensions/vscode-vue-language-features/bin/vite.js
+++ b/extensions/vscode-vue-language-features/bin/vite.js
@@ -109,11 +109,11 @@ function __installPreview(app) {
                     var _a;
                     if (((_a = event.data) === null || _a === void 0 ? void 0 : _a.command) === 'updateUrl') {
                         url.value = new URL(event.data.data);
-                        _file.value = url.value.hash.substr(1);
+                        _file.value = url.value.hash.slice(1);
                     }
                 });
                 var url = ref(new URL(location.href));
-                var _file = ref(url.value.hash.substr(1));
+                var _file = ref(url.value.hash.slice(1));
                 var file = computed(function () {
                     // fix windows path for vite
                     var path = _file.value.replace(/\\\\\\\\/g, '/');

--- a/packages/experimental/src/client.ts
+++ b/packages/experimental/src/client.ts
@@ -101,11 +101,11 @@ function installPreview(app: App) {
 				window.addEventListener('message', event => {
 					if (event.data?.command === 'updateUrl') {
 						url.value = new URL(event.data.data);
-						_file.value = url.value.hash.substr(1);
+						_file.value = url.value.hash.slice(1);
 					}
 				});
 				const url = ref(new URL(location.href));
-				const _file = ref(url.value.hash.substr(1));
+				const _file = ref(url.value.hash.slice(1));
 				const file = computed(() => {
 					// fix windows path for vite
 					let path = _file.value.replace(/\\/g, '/');

--- a/packages/pug-language-service/src/baseParse.ts
+++ b/packages/pug-language-service/src/baseParse.ts
@@ -214,7 +214,7 @@ export function baseParse(pugCode: string) {
 			if (typeof attr.val !== 'boolean') {
 				codeGen.addText(' ');
 				codeGen.addCode(
-					attr.val.substr(1, attr.val.length - 2), // remove "
+					attr.val.slice(1, -1), // remove "
 					getDocRange(attr.line, attr.column + 1, attr.val.length - 2),
 					SourceMap.Mode.Offset,
 					undefined
@@ -285,7 +285,7 @@ export function baseParse(pugCode: string) {
 						if (typeof attrToken.val === 'string' && attrText.indexOf('=') >= 0) {
 							let valText = attrToken.val;
 							if (valText.startsWith('`') && valText.endsWith('`')) {
-								valText = `"${valText.substr(1, valText.length - 2)}"`;
+								valText = `"${valText.slice(1, -1)}"`;
 							}
 							valText = valText.replace(/ \\\n/g, '//\n');
 							text += attrText.substring(0, attrText.lastIndexOf(attrToken.val)) + valText;

--- a/packages/shared/src/common.ts
+++ b/packages/shared/src/common.ts
@@ -111,5 +111,5 @@ export function getLineText(document: TextDocument, line: number) {
 		start: { line: line, character: 0 },
 		end: { line: line + 1, character: 0 },
 	});
-	return text.substr(0, text.length - 1);
+	return text.slice(0, -1);
 }

--- a/packages/typescript-language-service/src/index.ts
+++ b/packages/typescript-language-service/src/index.ts
@@ -107,7 +107,7 @@ export function createLanguageService(
 			const scriptSnapshot = host.getScriptSnapshot(fileName);
 			if (scriptSnapshot) {
 				const scriptText = scriptSnapshot.getText(0, scriptSnapshot.getLength());
-				const document = TextDocument.create(uri, shared.syntaxToLanguageId(path.extname(uri).substr(1)), oldDoc ? oldDoc[1].version + 1 : 0, scriptText);
+				const document = TextDocument.create(uri, shared.syntaxToLanguageId(path.extname(uri).slice(1)), oldDoc ? oldDoc[1].version + 1 : 0, scriptText);
 				documents.uriSet(uri, [version, document]);
 			}
 		}

--- a/packages/typescript-language-service/src/utils/previewer.ts
+++ b/packages/typescript-language-service/src/utils/previewer.ts
@@ -55,7 +55,7 @@ function getTagBodyText(
 			// check for caption tags, fix for #79704
 			const captionTagMatches = text.match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/);
 			if (captionTagMatches && captionTagMatches.index === 0) {
-				return captionTagMatches[1] + '\n\n' + makeCodeblock(text.substr(captionTagMatches[0].length));
+				return captionTagMatches[1] + '\n\n' + makeCodeblock(text.slice(captionTagMatches[0].length));
 			} else {
 				return makeCodeblock(text);
 			}

--- a/packages/vue-code-gen/src/generators/template.ts
+++ b/packages/vue-code-gen/src/generators/template.ts
@@ -171,7 +171,7 @@ export function generate(
 
 		const name1 = tagName; // hello-world
 		const name2 = camelize(tagName); // helloWorld
-		const name3 = name2[0].toUpperCase() + name2.substr(1); // HelloWorld
+		const name3 = name2[0].toUpperCase() + name2.slice(1); // HelloWorld
 		const componentNames = new Set([name1, name2, name3]);
 
 		if (!isScriptSetup) {
@@ -317,7 +317,7 @@ export function generate(
 							applyNewName(oldName, newName) {
 								const hName = hyphenate(newName);
 								if (hyphenate(newName).startsWith('on-')) {
-									return camelize(hName.substr('on-'.length));
+									return camelize(hName.slice('on-'.length));
 								}
 								return newName;
 							},
@@ -704,7 +704,7 @@ export function generate(
 											applyNewName(oldName, newName) {
 												const hName = hyphenate(newName);
 												if (hyphenate(newName).startsWith('on-')) {
-													return camelize(hName.substr('on-'.length));
+													return camelize(hName.slice('on-'.length));
 												}
 												return newName;
 											},

--- a/packages/vue-code-gen/src/parsers/cssBindRanges.ts
+++ b/packages/vue-code-gen/src/parsers/cssBindRanges.ts
@@ -5,7 +5,7 @@ export function* getMatchBindTexts(nodeText: string) {
 		if (match.index !== undefined) {
 			const matchText = match[1] ?? match[2] ?? match[3];
 			if (matchText !== undefined) {
-				const offset = match.index + nodeText.substr(match.index).indexOf(matchText);
+				const offset = match.index + nodeText.slice(match.index).indexOf(matchText);
 				yield { start: offset, end: offset + matchText.length };
 			}
 		}

--- a/packages/vue-language-server/src/project.ts
+++ b/packages/vue-language-server/src/project.ts
@@ -92,7 +92,7 @@ export async function createProject(
 					runtimeEnv.fileSystemProvide,
 					(uri) => {
 
-						const protocol = uri.substr(0, uri.indexOf(':'));
+						const protocol = uri.substring(0, uri.indexOf(':'));
 
 						const builtInHandler = runtimeEnv.schemaRequestHandlers[protocol];
 						if (builtInHandler) {

--- a/packages/vue-language-service/src/commonPlugins/pugBeautify.ts
+++ b/packages/vue-language-service/src/commonPlugins/pugBeautify.ts
@@ -20,8 +20,8 @@ export default function (): EmbeddedLanguagePlugin {
 
             const prefixesLength = pugCode.length - pugCode.trimStart().length;
             const suffixesLength = pugCode.length - pugCode.trimEnd().length;
-            const prefixes = pugCode.substr(0, prefixesLength);
-            const suffixes = pugCode.substr(pugCode.length - suffixesLength);
+            const prefixes = pugCode.slice(0, prefixesLength);
+            const suffixes = pugCode.slice(pugCode.length - suffixesLength);
             const newPugCode: string = pugBeautify(pugCode, {
                 tab_size: options.tabSize,
                 fill_tab: !options.insertSpaces,

--- a/packages/vue-language-service/src/vuePlugins/vueTemplateLanguage.ts
+++ b/packages/vue-language-service/src/vuePlugins/vueTemplateLanguage.ts
@@ -479,8 +479,8 @@ export default function (host: {
                     if (hyphenate(name).startsWith('on-')) {
 
                         const propNameBase = name.startsWith('on-')
-                            ? name.substr('on-'.length)
-                            : (name['on'.length].toLowerCase() + name.substr('onX'.length));
+                            ? name.slice('on-'.length)
+                            : (name['on'.length].toLowerCase() + name.slice('onX'.length));
                         const propKey = createInternalItemId('componentEvent', [componentName, propNameBase]);
 
                         attributes.push(

--- a/packages/vue-typescript/src/use/useSfcTemplateScript.ts
+++ b/packages/vue-typescript/src/use/useSfcTemplateScript.ts
@@ -474,7 +474,7 @@ export function useSfcTemplateScript(
 }
 
 function beforeCssRename(newName: string) {
-	return newName.startsWith('.') ? newName.substr(1) : newName;
+	return newName.startsWith('.') ? newName.slice(1) : newName;
 }
 function doCssRename(oldName: string, newName: string) {
 	return '.' + newName;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.