### PR TITLE
refactor: unused fs path in language service

### DIFF
--- a/packages/pug-language-service/src/baseParse.ts
+++ b/packages/pug-language-service/src/baseParse.ts
@@ -9,7 +9,7 @@ const pugParser = require('pug-parser');
 export function baseParse(pugCode: string) {
 
 	const fileName = 'foo.pug';
-	const pugTextDocument = TextDocument.create(shared.fsPathToUri('foo.pug'), 'jade', 0, pugCode);
+	const pugTextDocument = TextDocument.create('file:///foo.pug', 'jade', 0, pugCode);
 	const codeGen = new CodeGen<{ isEmptyTagCompletion: boolean } | undefined>();
 	let error: {
 		code: string,

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -1,14 +1,5 @@
 import { URI } from 'vscode-uri';
 import * as upath from 'upath';
-import type { DocumentUri } from 'vscode-languageserver-textdocument';
-
-export function uriToFsPath(uri: DocumentUri) {
-	return upath.toUnix(URI.parse(uri).fsPath);
-}
-
-export function fsPathToUri(fsPath: string): DocumentUri {
-	return URI.file(fsPath).toString();
-}
 
 export function normalizeFileName(fsPath: string) {
 	return upath.toUnix(URI.file(fsPath).fsPath);

--- a/packages/shared/src/uriMap.ts
+++ b/packages/shared/src/uriMap.ts
@@ -1,5 +1,4 @@
 import { URI } from 'vscode-uri';
-import { fsPathToUri } from './path';
 
 interface Options<T> {
 	delete(key: string): boolean;
@@ -22,21 +21,12 @@ export function createPathMap<T>(map: Options<T> = new Map<string, T>()) {
 		uriGet,
 		uriHas,
 		uriSet,
-		fsPathDelete,
-		fsPathGet,
-		fsPathHas,
-		fsPathSet,
 	};
 
 	function getUriByUri(uri: string) {
 		if (uriToUriKeys[uri] === undefined)
 			uriToUriKeys[uri] = normalizeUri(uri).toLowerCase();
 		return uriToUriKeys[uri];
-	}
-	function getUriByFsPath(fsPath: string) {
-		if (fsPathToUriKeys[fsPath] === undefined)
-			fsPathToUriKeys[fsPath] = fsPathToUri(fsPath).toLowerCase();
-		return fsPathToUriKeys[fsPath];
 	}
 
 	function clear() {
@@ -57,19 +47,6 @@ export function createPathMap<T>(map: Options<T> = new Map<string, T>()) {
 	}
 	function uriSet(_uri: string, item: T) {
 		return map.set(getUriByUri(_uri), item);
-	}
-
-	function fsPathDelete(_fsPath: string) {
-		return map.delete(getUriByFsPath(_fsPath));
-	}
-	function fsPathGet(_fsPath: string) {
-		return map.get(getUriByFsPath(_fsPath));
-	}
-	function fsPathHas(_fsPath: string) {
-		return map.has(getUriByFsPath(_fsPath));
-	}
-	function fsPathSet(_fsPath: string, item: T) {
-		return map.set(getUriByFsPath(_fsPath), item);
 	}
 }
 

--- a/packages/typescript-language-service/src/index.ts
+++ b/packages/typescript-language-service/src/index.ts
@@ -81,30 +81,28 @@ export function createLanguageService(
 			raw: languageService,
 			getTextDocument,
 			getValidTextDocument,
-			isValidFile,
+			isValidScript,
 			doCompleteSync: completions.register(languageService, getValidTextDocument, ts),
 		},
 	};
 
 	function getValidTextDocument(uri: string) {
-		const fileName = shared.uriToFsPath(uri);
-		if (!isValidFile(fileName)) {
+		if (!isValidScript(uri)) {
 			return;
 		}
 		return getTextDocument(uri);
 	}
-	function isValidFile(fileName: string) {
-		if (!languageService.getProgram()?.getSourceFile(fileName)) {
+	function isValidScript(uri: string) {
+		if (!languageService.getProgram()?.getSourceFile(uri)) {
 			return false;
 		}
 		return true;
 	}
 	function getTextDocument(uri: string) {
-		const fileName = shared.uriToFsPath(uri);
-		const version = host.getScriptVersion(fileName);
+		const version = host.getScriptVersion(uri);
 		const oldDoc = documents.uriGet(uri);
 		if (!oldDoc || oldDoc[0] !== version) {
-			const scriptSnapshot = host.getScriptSnapshot(fileName);
+			const scriptSnapshot = host.getScriptSnapshot(uri);
 			if (scriptSnapshot) {
 				const scriptText = scriptSnapshot.getText(0, scriptSnapshot.getLength());
 				const document = TextDocument.create(uri, shared.syntaxToLanguageId(path.extname(uri).slice(1)), oldDoc ? oldDoc[1].version + 1 : 0, scriptText);

--- a/packages/typescript-language-service/src/services/codeActionResolve.ts
+++ b/packages/typescript-language-service/src/services/codeActionResolve.ts
@@ -24,21 +24,21 @@ export function register(
 		if (data?.type === 'fixAll') {
 			const fixs = data.fixIds.map(fixId => {
 				try {
-					return languageService.getCombinedCodeFix({ type: 'file', fileName: data.fileName }, fixId, formatOptions, preferences);
+					return languageService.getCombinedCodeFix({ type: 'file', fileName: data.uri }, fixId, formatOptions, preferences);
 				} catch { }
 			});
 			const changes = fixs.map(fix => fix?.changes ?? []).flat();
 			codeAction.edit = fileTextChangesToWorkspaceEdit(changes, getTextDocument);
 		}
 		else if (data?.type === 'refactor') {
-			const editInfo = languageService.getEditsForRefactor(data.fileName, formatOptions, data.range, data.refactorName, data.actionName, preferences);
+			const editInfo = languageService.getEditsForRefactor(data.uri, formatOptions, data.range, data.refactorName, data.actionName, preferences);
 			if (editInfo) {
 				const edit = fileTextChangesToWorkspaceEdit(editInfo.edits, getTextDocument);
 				codeAction.edit = edit;
 			}
 		}
 		else if (data?.type === 'organizeImports') {
-			const changes = languageService.organizeImports({ type: 'file', fileName: data.fileName }, formatOptions, preferences);
+			const changes = languageService.organizeImports({ type: 'file', fileName: data.uri }, formatOptions, preferences);
 			const edit = fileTextChangesToWorkspaceEdit(changes, getTextDocument);
 			codeAction.edit = edit;
 		}

--- a/packages/typescript-language-service/src/services/completion.ts
+++ b/packages/typescript-language-service/src/services/completion.ts
@@ -2,13 +2,11 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as PConst from '../protocol.const';
 import * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import * as shared from '@volar/shared';
 import * as semver from 'semver';
 import { parseKindModifier } from '../utils/modifiers';
 
 export interface Data {
 	uri: string,
-	fileName: string,
 	offset: number,
 	originalItem: ts.CompletionEntry
 }
@@ -41,11 +39,10 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return;
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let completionContext: ReturnType<typeof languageService.getCompletionsAtPosition> | undefined;
-		try { completionContext = languageService.getCompletionsAtPosition(fileName, offset, options); } catch { }
+		try { completionContext = languageService.getCompletionsAtPosition(document.uri, offset, options); } catch { }
 		if (completionContext === undefined) return;
 
 		const wordRange = completionContext.optionalReplacementSpan ? vscode.Range.create(
@@ -129,7 +126,6 @@ export function register(
 
 				const data: Data = {
 					uri,
-					fileName,
 					offset,
 					originalItem: tsEntry,
 				};

--- a/packages/typescript-language-service/src/services/definition.ts
+++ b/packages/typescript-language-service/src/services/definition.ts
@@ -1,7 +1,6 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
 import { boundSpanToLocationLinks } from '../utils/transforms';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 export function register(
@@ -14,11 +13,10 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let info: ReturnType<typeof languageService.getDefinitionAndBoundSpan> | undefined;
-		try { info = languageService.getDefinitionAndBoundSpan(fileName, offset); } catch { }
+		try { info = languageService.getDefinitionAndBoundSpan(document.uri, offset); } catch { }
 		if (!info) return [];
 
 		return boundSpanToLocationLinks(info, document, getTextDocument2);

--- a/packages/typescript-language-service/src/services/diagnostics.ts
+++ b/packages/typescript-language-service/src/services/diagnostics.ts
@@ -17,9 +17,8 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const program = languageService.getProgram();
-		const sourceFile = program?.getSourceFile(fileName);
+		const sourceFile = program?.getSourceFile(document.uri);
 		if (!program || !sourceFile) return [];
 
 		let errors: ts.Diagnostic[] = [];
@@ -28,7 +27,7 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 			errors = [
 				...options.semantic ? program.getSemanticDiagnostics(sourceFile, cancellationToken) : [],
 				...options.syntactic ? program.getSyntacticDiagnostics(sourceFile, cancellationToken) : [],
-				...options.suggestion ? languageService.getSuggestionDiagnostics(fileName) : [],
+				...options.suggestion ? languageService.getSuggestionDiagnostics(document.uri) : [],
 			];
 
 			if (options.declaration && getEmitDeclarations(program.getCompilerOptions())) {
@@ -81,7 +80,7 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 
 			let document: TextDocument | undefined;
 			if (diag.file) {
-				document = getTextDocument(shared.fsPathToUri(diag.file.fileName));
+				document = getTextDocument(diag.file.fileName);
 			}
 			if (!document) return;
 

--- a/packages/typescript-language-service/src/services/documentHighlight.ts
+++ b/packages/typescript-language-service/src/services/documentHighlight.ts
@@ -9,11 +9,10 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let highlights: ReturnType<typeof languageService.getDocumentHighlights> | undefined;
-		try { highlights = languageService.getDocumentHighlights(fileName, offset, [fileName]); } catch { }
+		try { highlights = languageService.getDocumentHighlights(document.uri, offset, [document.uri]); } catch { }
 		if (!highlights) return [];
 
 		const results: vscode.DocumentHighlight[] = [];

--- a/packages/typescript-language-service/src/services/documentSymbol.ts
+++ b/packages/typescript-language-service/src/services/documentSymbol.ts
@@ -2,7 +2,6 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as PConst from '../protocol.const';
 import * as vscode from 'vscode-languageserver-protocol';
 import { parseKindModifier } from '../utils/modifiers';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 const getSymbolKind = (kind: string): vscode.SymbolKind => {
@@ -32,10 +31,8 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
-
 		let barItems: ReturnType<typeof languageService.getNavigationTree> | undefined;
-		try { barItems = languageService.getNavigationTree(fileName); } catch { }
+		try { barItems = languageService.getNavigationTree(document.uri); } catch { }
 		if (!barItems) return [];
 
 		// The root represents the file. Ignore this when showing in the UI

--- a/packages/typescript-language-service/src/services/fileRename.ts
+++ b/packages/typescript-language-service/src/services/fileRename.ts
@@ -1,7 +1,6 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import * as shared from '@volar/shared';
 import { fileTextChangesToWorkspaceEdit } from './rename';
 import type { Settings } from '../';
 
@@ -18,11 +17,8 @@ export function register(
 			settings.getPreferences?.(document) ?? {},
 		]) : [{}, {}];
 
-		const fileToRename = shared.uriToFsPath(oldUri);
-		const newFilePath = shared.uriToFsPath(newUri);
-
 		let response: ReturnType<typeof languageService.getEditsForFileRename> | undefined;
-		try { response = languageService.getEditsForFileRename(fileToRename, newFilePath, formatOptions, preferences); } catch { }
+		try { response = languageService.getEditsForFileRename(oldUri, newUri, formatOptions, preferences); } catch { }
 		if (!response?.length) return;
 
 		const edits = fileTextChangesToWorkspaceEdit(response, getTextDocument);

--- a/packages/typescript-language-service/src/services/foldingRanges.ts
+++ b/packages/typescript-language-service/src/services/foldingRanges.ts
@@ -1,7 +1,6 @@
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
-import * as shared from '@volar/shared';
 
 export function register(languageService: ts.LanguageService, getTextDocument: (uri: string) => TextDocument | undefined, ts: typeof import('typescript/lib/tsserverlibrary')) {
 	return (uri: string) => {
@@ -9,10 +8,8 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
-
 		let outliningSpans: ReturnType<typeof languageService.getOutliningSpans> | undefined;
-		try { outliningSpans = languageService.getOutliningSpans(fileName); } catch { }
+		try { outliningSpans = languageService.getOutliningSpans(document.uri); } catch { }
 		if (!outliningSpans) return [];
 
 		const foldingRanges: vscode.FoldingRange[] = [];

--- a/packages/typescript-language-service/src/services/formatting.ts
+++ b/packages/typescript-language-service/src/services/formatting.ts
@@ -1,6 +1,5 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Settings } from '../';
 
@@ -13,14 +12,13 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const tsOptions = await settings.getFormatOptions?.(document, options) ?? options;
 
 		let scriptEdits: ReturnType<typeof languageService.getFormattingEditsForRange> | undefined;
 		try {
 			scriptEdits = range
-				? languageService.getFormattingEditsForRange(fileName, document.offsetAt(range.start), document.offsetAt(range.end), tsOptions)
-				: languageService.getFormattingEditsForDocument(fileName, tsOptions);
+				? languageService.getFormattingEditsForRange(document.uri, document.offsetAt(range.start), document.offsetAt(range.end), tsOptions)
+				: languageService.getFormattingEditsForDocument(document.uri, tsOptions);
 		} catch { }
 		if (!scriptEdits) return [];
 

--- a/packages/typescript-language-service/src/services/hover.ts
+++ b/packages/typescript-language-service/src/services/hover.ts
@@ -1,7 +1,6 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
 import * as previewer from '../utils/previewer';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 export function register(
@@ -14,16 +13,15 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return;
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let info: ReturnType<typeof languageService.getQuickInfoAtPosition> | undefined;
-		try { info = languageService.getQuickInfoAtPosition(fileName, offset); } catch { }
+		try { info = languageService.getQuickInfoAtPosition(document.uri, offset); } catch { }
 		if (!info) return;
 
 		const parts: string[] = [];
 		const displayString = ts.displayPartsToString(info.displayParts);
-		const documentation = previewer.markdownDocumentation(info.documentation ?? [], info.tags, { toResource: shared.fsPathToUri }, getTextDocument2);
+		const documentation = previewer.markdownDocumentation(info.documentation ?? [], info.tags, { toResource: uri => uri }, getTextDocument2);
 
 		if (displayString && !documentOnly) {
 			parts.push(['```typescript', displayString, '```'].join('\n'));

--- a/packages/typescript-language-service/src/services/implementation.ts
+++ b/packages/typescript-language-service/src/services/implementation.ts
@@ -1,7 +1,6 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { entriesToLocationLinks } from '../utils/transforms';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 export function register(
@@ -13,11 +12,10 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let entries: ReturnType<typeof languageService.getImplementationAtPosition>;
-		try { entries = languageService.getImplementationAtPosition(fileName, offset); } catch { }
+		try { entries = languageService.getImplementationAtPosition(document.uri, offset); } catch { }
 		if (!entries) return [];
 
 		return entriesToLocationLinks([...entries], getTextDocument2);

--- a/packages/typescript-language-service/src/services/jsDocCompletions.ts
+++ b/packages/typescript-language-service/src/services/jsDocCompletions.ts
@@ -21,10 +21,9 @@ export function register(
 		if (!isPotentiallyValidDocCompletionPosition(document, position))
 			return;
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
-		const docCommentTemplate = languageService.getDocCommentTemplateAtPosition(fileName, offset);
+		const docCommentTemplate = languageService.getDocCommentTemplateAtPosition(document.uri, offset);
 		if (!docCommentTemplate)
 			return;
 

--- a/packages/typescript-language-service/src/services/prepareRename.ts
+++ b/packages/typescript-language-service/src/services/prepareRename.ts
@@ -1,6 +1,5 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 /* typescript-language-features is hardcode true */
@@ -14,11 +13,10 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return;
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let renameInfo: ReturnType<typeof languageService.getRenameInfo> | undefined;
-		try { renameInfo = languageService.getRenameInfo(fileName, offset, renameInfoOptions); } catch { }
+		try { renameInfo = languageService.getRenameInfo(document.uri, offset, renameInfoOptions); } catch { }
 		if (!renameInfo) return;
 
 		if (!renameInfo.canRename) {

--- a/packages/typescript-language-service/src/services/references.ts
+++ b/packages/typescript-language-service/src/services/references.ts
@@ -1,7 +1,6 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
 import { entriesToLocations } from '../utils/transforms';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 export function register(
@@ -13,11 +12,10 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let entries: ReturnType<typeof languageService.getReferencesAtPosition>;
-		try { entries = languageService.getReferencesAtPosition(fileName, offset); } catch { }
+		try { entries = languageService.getReferencesAtPosition(document.uri, offset); } catch { }
 		if (!entries) return [];
 
 		return entriesToLocations([...entries], getTextDocument2);

--- a/packages/typescript-language-service/src/services/selectionRanges.ts
+++ b/packages/typescript-language-service/src/services/selectionRanges.ts
@@ -1,4 +1,3 @@
-import * as shared from '@volar/shared';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
@@ -12,11 +11,10 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 		const result: vscode.SelectionRange[] = [];
 
 		for (const position of positions) {
-			const fileName = shared.uriToFsPath(document.uri);
 			const offset = document.offsetAt(position);
 
 			let range: ReturnType<typeof languageService.getSmartSelectionRange> | undefined;
-			try { range = languageService.getSmartSelectionRange(fileName, offset); } catch { }
+			try { range = languageService.getSmartSelectionRange(document.uri, offset); } catch { }
 			if (!range) continue;
 
 			result.push(transformSelectionRange(range, document));

--- a/packages/typescript-language-service/src/services/semanticTokens.ts
+++ b/packages/typescript-language-service/src/services/semanticTokens.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import * as shared from '@volar/shared';
 
 export function getSemanticTokenLegend(): vscode.SemanticTokensLegend {
 	if (tokenTypes.length !== TokenType._) {
@@ -23,18 +22,17 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return;
 
-		const file = shared.uriToFsPath(uri);
 		const start = range ? document.offsetAt(range.start) : 0;
 		const length = range ? (document.offsetAt(range.end) - start) : document.getText().length;
 
 		if (cancle?.isCancellationRequested) return;
 		let response2: ReturnType<typeof languageService.getEncodedSyntacticClassifications> | undefined;
-		try { response2 = languageService.getEncodedSyntacticClassifications(file, { start, length }); } catch { }
+		try { response2 = languageService.getEncodedSyntacticClassifications(document.uri, { start, length }); } catch { }
 		if (!response2) return;
 
 		if (cancle?.isCancellationRequested) return;
 		let response1: ReturnType<typeof languageService.getEncodedSemanticClassifications> | undefined;
-		try { response1 = languageService.getEncodedSemanticClassifications(file, { start, length }, ts.SemanticClassificationFormat.TwentyTwenty); } catch { }
+		try { response1 = languageService.getEncodedSemanticClassifications(document.uri, { start, length }, ts.SemanticClassificationFormat.TwentyTwenty); } catch { }
 		if (!response1) return;
 
 		const tokenSpan = [...response1.spans, ...response2.spans];

--- a/packages/typescript-language-service/src/services/signatureHelp.ts
+++ b/packages/typescript-language-service/src/services/signatureHelp.ts
@@ -27,11 +27,10 @@ export function register(languageService: ts.LanguageService, getTextDocument: (
 			};
 		}
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let helpItems: ReturnType<typeof languageService.getSignatureHelpItems> | undefined;
-		try { helpItems = languageService.getSignatureHelpItems(fileName, offset, options); } catch { }
+		try { helpItems = languageService.getSignatureHelpItems(document.uri, offset, options); } catch { }
 		if (!helpItems) return;
 
 		return {

--- a/packages/typescript-language-service/src/services/typeDefinition.ts
+++ b/packages/typescript-language-service/src/services/typeDefinition.ts
@@ -1,7 +1,6 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import type * as vscode from 'vscode-languageserver-protocol';
 import { entriesToLocationLinks } from '../utils/transforms';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 export function register(
@@ -13,11 +12,10 @@ export function register(
 		const document = getTextDocument(uri);
 		if (!document) return [];
 
-		const fileName = shared.uriToFsPath(document.uri);
 		const offset = document.offsetAt(position);
 
 		let entries: ReturnType<typeof languageService.getTypeDefinitionAtPosition>;
-		try { entries = languageService.getTypeDefinitionAtPosition(fileName, offset); } catch { }
+		try { entries = languageService.getTypeDefinitionAtPosition(document.uri, offset); } catch { }
 		if (!entries) return [];
 
 		return entriesToLocationLinks([...entries], getTextDocument2);

--- a/packages/typescript-language-service/src/services/workspaceSymbol.ts
+++ b/packages/typescript-language-service/src/services/workspaceSymbol.ts
@@ -36,15 +36,14 @@ export function register(languageService: ts.LanguageService, getTextDocument2: 
 
 		function toSymbolInformation(item: ts.NavigateToItem) {
 			const label = getLabel(item);
-			const uri = shared.fsPathToUri(item.fileName);
-			const document = getTextDocument2(uri);
+			const document = getTextDocument2(item.fileName);
 			if (document) {
 				const range = vscode.Range.create(document.positionAt(item.textSpan.start), document.positionAt(item.textSpan.start + item.textSpan.length));
 				const info = vscode.SymbolInformation.create(
 					label,
 					getSymbolKind(item),
 					range,
-					uri,
+					item.fileName,
 					item.containerName || '',
 				);
 				const kindModifiers = item.kindModifiers ? parseKindModifier(item.kindModifiers) : undefined;

--- a/packages/typescript-language-service/src/utils/previewer.ts
+++ b/packages/typescript-language-service/src/utils/previewer.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as Proto from '../protocol';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 export interface IFilePathToResourceConverter {
@@ -145,7 +144,7 @@ function convertLinkTags(
 							fileName: string,
 							textSpan: { start: number, length: number },
 						};
-						const fileDoc = getTextDocument(shared.uriToFsPath(_target.fileName));
+						const fileDoc = getTextDocument(_target.fileName);
 						if (fileDoc) {
 							const start = fileDoc.positionAt(_target.textSpan.start);
 							const end = fileDoc.positionAt(_target.textSpan.start + _target.textSpan.length);

--- a/packages/typescript-language-service/src/utils/transforms.ts
+++ b/packages/typescript-language-service/src/utils/transforms.ts
@@ -1,20 +1,17 @@
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import * as vscode from 'vscode-languageserver-protocol';
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 export function entriesToLocations(entries: { fileName: string, textSpan: ts.TextSpan }[], getTextDocument: (uri: string) => TextDocument | undefined) {
 	const locations: vscode.Location[] = [];
 	for (const entry of entries) {
-		const entryUri = shared.fsPathToUri(entry.fileName);
-		const doc = getTextDocument(entryUri);
+		const doc = getTextDocument(entry.fileName);
 		if (!doc) continue;
 		const range = vscode.Range.create(
 			doc.positionAt(entry.textSpan.start),
 			doc.positionAt(entry.textSpan.start + entry.textSpan.length),
 		);
-		const uri = shared.fsPathToUri(entry.fileName);
-		const location = vscode.Location.create(uri, range);
+		const location = vscode.Location.create(entry.fileName, range);
 		locations.push(location);
 	}
 	return locations;
@@ -22,8 +19,7 @@ export function entriesToLocations(entries: { fileName: string, textSpan: ts.Tex
 export function entriesToLocationLinks<T extends ts.DocumentSpan>(entries: T[], getTextDocument: (uri: string) => TextDocument | undefined): vscode.LocationLink[] {
 	const locations: vscode.LocationLink[] = [];
 	for (const entry of entries) {
-		const entryUri = shared.fsPathToUri(entry.fileName);
-		const doc = getTextDocument(entryUri);
+		const doc = getTextDocument(entry.fileName);
 		if (!doc) continue;
 		const targetSelectionRange = vscode.Range.create(
 			doc.positionAt(entry.textSpan.start),
@@ -37,8 +33,7 @@ export function entriesToLocationLinks<T extends ts.DocumentSpan>(entries: T[], 
 			doc.positionAt(entry.originalTextSpan.start),
 			doc.positionAt(entry.originalTextSpan.start + entry.originalTextSpan.length),
 		) : undefined;
-		const uri = shared.fsPathToUri(entry.fileName);
-		const location = vscode.LocationLink.create(uri, targetRange, targetSelectionRange, originSelectionRange);
+		const location = vscode.LocationLink.create(entry.fileName, targetRange, targetSelectionRange, originSelectionRange);
 		locations.push(location);
 	}
 	return locations;
@@ -51,8 +46,7 @@ export function boundSpanToLocationLinks(info: ts.DefinitionInfoAndBoundSpan, or
 		originalDoc.positionAt(info.textSpan.start + info.textSpan.length),
 	);
 	for (const entry of info.definitions) {
-		const entryUri = shared.fsPathToUri(entry.fileName);
-		const doc = getTextDocument(entryUri);
+		const doc = getTextDocument(entry.fileName);
 		if (!doc) continue;
 		const targetSelectionRange = vscode.Range.create(
 			doc.positionAt(entry.textSpan.start),
@@ -62,8 +56,7 @@ export function boundSpanToLocationLinks(info: ts.DefinitionInfoAndBoundSpan, or
 			doc.positionAt(entry.contextSpan.start),
 			doc.positionAt(entry.contextSpan.start + entry.contextSpan.length),
 		) : targetSelectionRange;
-		const uri = shared.fsPathToUri(entry.fileName);
-		const location = vscode.LocationLink.create(uri, targetRange, targetSelectionRange, originSelectionRange);
+		const location = vscode.LocationLink.create(entry.fileName, targetRange, targetSelectionRange, originSelectionRange);
 		locations.push(location);
 	}
 	return locations;

--- a/packages/vue-language-server/src/configHost.ts
+++ b/packages/vue-language-server/src/configHost.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode-languageserver';
 import { ConfigurationHost } from '@volar/vue-language-service';
 
-export function createLsConfigs(rootFolders: string[], connection: vscode.Connection): ConfigurationHost {
+export function createLsConfigs(rootFolderUris: string[], connection: vscode.Connection): ConfigurationHost {
 
 	let settings: Record<string, Record<string, Promise<any>>> = {};
 
@@ -28,6 +28,6 @@ export function createLsConfigs(rootFolders: string[], connection: vscode.Connec
 		onDidChangeConfiguration(cb) {
 			callbacks.push(cb);
 		},
-		rootUris: rootFolders,
+		rootUris: rootFolderUris,
 	};
 }

--- a/packages/vue-language-server/src/features/customFeatures.ts
+++ b/packages/vue-language-server/src/features/customFeatures.ts
@@ -34,9 +34,9 @@ export function register(
 					connection.workspace.applyEdit({
 						edit: {
 							documentChanges: [
-								vscode.CreateFile.create(shared.fsPathToUri(fileName)),
+								vscode.CreateFile.create(fileName),
 								vscode.TextDocumentEdit.create(
-									vscode.OptionalVersionedTextDocumentIdentifier.create(shared.fsPathToUri(fileName), null),
+									vscode.OptionalVersionedTextDocumentIdentifier.create(fileName, null),
 									[{ range: vscode.Range.create(0, 0, 0, 0), newText: localTypes.code }],
 								),
 							]
@@ -83,7 +83,7 @@ export function register(
 				const allVueDocuments = context.vueDocuments.getAll();
 				let i = 0;
 				for (const vueFile of allVueDocuments) {
-					progress.report(i++ / allVueDocuments.length * 100, path.relative(ls.__internal__.rootPath, shared.uriToFsPath(vueFile.uri)));
+					progress.report(i++ / allVueDocuments.length * 100, path.relative(ls.__internal__.vueLsHost.getCurrentDirectory(), vueFile.uri));
 					if (progress.token.isCancellationRequested) {
 						continue;
 					}

--- a/packages/vue-language-server/src/features/languageFeatures.ts
+++ b/packages/vue-language-server/src/features/languageFeatures.ts
@@ -223,7 +223,7 @@ export function register(
 		if (config === 'always') {
 			const renaming = new Promise<void>(async resolve => {
 				for (const file of handler.files) {
-					const renameFileContent = getScriptText(documents, shared.uriToFsPath(file.oldUri), ts.sys);
+					const renameFileContent = getScriptText(documents, file.oldUri, ts.sys);
 					if (renameFileContent) {
 						renameFileContentCache.set(file.oldUri, renameFileContent);
 					}

--- a/packages/vue-language-server/src/node.ts
+++ b/packages/vue-language-server/src/node.ts
@@ -6,7 +6,7 @@ import httpSchemaRequestHandler from './schemaRequestHandlers/http';
 import * as path from 'upath';
 import * as html from 'vscode-html-languageservice';
 import * as fs from 'fs';
-import * as shared from '@volar/shared';
+import { URI } from 'vscode-uri';
 
 const connection = vscode.createConnection(vscode.ProposedFeatures.all);
 
@@ -31,8 +31,9 @@ createLanguageServer(connection, {
     },
     fileSystemProvide: {
         stat: (uri) => {
+            const parsedUri = URI.parse(uri);
             return new Promise<html.FileStat>((resolve, reject) => {
-                fs.stat(shared.uriToFsPath(uri), (err, stats) => {
+                fs.stat(parsedUri.fsPath, (err, stats) => {
                     if (stats) {
                         resolve({
                             type: stats.isFile() ? html.FileType.File
@@ -51,8 +52,9 @@ createLanguageServer(connection, {
             });
         },
         readDirectory: (uri) => {
+            const parsedUri = URI.parse(uri);
             return new Promise<[string, html.FileType][]>((resolve, reject) => {
-                fs.readdir(shared.uriToFsPath(uri), (err, files) => {
+                fs.readdir(parsedUri.fsPath, (err, files) => {
                     if (files) {
                         resolve(files.map(file => [file, html.FileType.File]));
                     }

--- a/packages/vue-language-service/src/commonPlugins/css.ts
+++ b/packages/vue-language-service/src/commonPlugins/css.ts
@@ -195,32 +195,32 @@ export default function (host: {
 
         if (host.configurationHost) {
 
-            const paths = new Set<string>();
-            const customData: string[] = await host.configurationHost.getConfiguration('css.customData') ?? [];
-            const rootPaths = host.configurationHost.rootUris.map(shared.uriToFsPath);
+            // const paths = new Set<string>();
+            // const customData: string[] = await host.configurationHost.getConfiguration('css.customData') ?? [];
+            // const rootPaths = host.configurationHost.rootUris.map(shared.uriToFsPath);
 
-            for (const customDataPath of customData) {
-                try {
-                    const jsonPath = require.resolve(customDataPath, { paths: rootPaths });
-                    paths.add(jsonPath);
-                }
-                catch (error) {
-                    console.error(error);
-                }
-            }
+            // for (const customDataPath of customData) {
+            //     try {
+            //         const jsonPath = require.resolve(customDataPath, { paths: rootPaths });
+            //         paths.add(jsonPath);
+            //     }
+            //     catch (error) {
+            //         console.error(error);
+            //     }
+            // }
 
-            const newData: css.ICSSDataProvider[] = [];
+            // const newData: css.ICSSDataProvider[] = [];
 
-            for (const path of paths) {
-                try {
-                    newData.push(css.newCSSDataProvider(require(path)));
-                }
-                catch (error) {
-                    console.error(error);
-                }
-            }
+            // for (const path of paths) {
+            //     try {
+            //         newData.push(css.newCSSDataProvider(require(path)));
+            //     }
+            //     catch (error) {
+            //         console.error(error);
+            //     }
+            // }
 
-            return newData;
+            // return newData;
         }
 
         return [];

--- a/packages/vue-language-service/src/commonPlugins/html.ts
+++ b/packages/vue-language-service/src/commonPlugins/html.ts
@@ -161,32 +161,32 @@ export default function (host: {
 
         if (host.configurationHost) {
 
-            const paths = new Set<string>();
-            const customData: string[] = await host.configurationHost.getConfiguration('html.customData') ?? [];
-            const rootPaths = host.configurationHost.rootUris.map(shared.uriToFsPath);
+            // const paths = new Set<string>();
+            // const customData: string[] = await host.configurationHost.getConfiguration('html.customData') ?? [];
+            // const rootPaths = host.configurationHost.rootUris.map(shared.uriToFsPath);
 
-            for (const customDataPath of customData) {
-                try {
-                    const jsonPath = require.resolve(customDataPath, { paths: rootPaths });
-                    paths.add(jsonPath);
-                }
-                catch (error) {
-                    console.error(error);
-                }
-            }
+            // for (const customDataPath of customData) {
+            //     try {
+            //         const jsonPath = require.resolve(customDataPath, { paths: rootPaths });
+            //         paths.add(jsonPath);
+            //     }
+            //     catch (error) {
+            //         console.error(error);
+            //     }
+            // }
 
-            const newData: html.IHTMLDataProvider[] = [];
+            // const newData: html.IHTMLDataProvider[] = [];
 
-            for (const path of paths) {
-                try {
-                    newData.push(html.newHTMLDataProvider(path, require(path)));
-                }
-                catch (error) {
-                    console.error(error);
-                }
-            }
+            // for (const path of paths) {
+            //     try {
+            //         newData.push(html.newHTMLDataProvider(path, require(path)));
+            //     }
+            //     catch (error) {
+            //         console.error(error);
+            //     }
+            // }
 
-            return newData;
+            // return newData;
         }
 
         return [];

--- a/packages/vue-language-service/src/documentService.ts
+++ b/packages/vue-language-service/src/documentService.ts
@@ -147,7 +147,7 @@ export function getDocumentService(
 		}
 
 		const vueFile = vueTs.createVueFile(
-			shared.uriToFsPath(document.uri),
+			document.uri,
 			document.getText(),
 			document.version.toString(),
 			vueTsPlugins,

--- a/packages/vue-language-service/src/languageFuatures/callHierarchy.ts
+++ b/packages/vue-language-service/src/languageFuatures/callHierarchy.ts
@@ -1,5 +1,4 @@
 import * as shared from '@volar/shared';
-import * as upath from 'upath';
 import type * as vscode from 'vscode-languageserver-protocol';
 import type { LanguageServiceRuntimeContext } from '../types';
 import * as dedupe from '../utils/dedupe';
@@ -208,7 +207,10 @@ export function register(context: LanguageServiceRuntimeContext) {
 		const vueRanges = tsRanges.map(tsRange => sourceMap.getSourceRange(tsRange.start, tsRange.end)?.[0]).filter(shared.notEmpty);
 		const vueItem: vscode.CallHierarchyItem = {
 			...tsItem,
-			name: tsItem.name === upath.basename(shared.uriToFsPath(sourceMap.mappedDocument.uri)) ? upath.basename(shared.uriToFsPath(sourceMap.sourceDocument.uri)) : tsItem.name,
+			name: tsItem.name ===
+				sourceMap.mappedDocument.uri.substring(sourceMap.mappedDocument.uri.lastIndexOf('/') + 1)
+				? sourceMap.mappedDocument.uri.substring(sourceMap.sourceDocument.uri.lastIndexOf('/') + 1)
+				: tsItem.name,
 			uri: sourceMap.sourceDocument.uri,
 			range: vueRange,
 			selectionRange: vueSelectionRange,

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -361,8 +361,8 @@ export function createLanguageService(
 		},
 
 		__internal__: {
+			vueLsHost,
 			tsRuntime,
-			rootPath: vueLsHost.getCurrentDirectory(),
 			context,
 			getContext: defineApi(() => context, true),
 			// getD3: defineApi(d3.register(context), true), // unused for now
@@ -371,54 +371,54 @@ export function createLanguageService(
 	};
 
 	function getDocumentContext() {
-		const compilerHost = ts.createCompilerHost(vueLsHost.getCompilationSettings());
+		// const compilerHost = ts.createCompilerHost(vueLsHost.getCompilationSettings());
 		const documentContext: html.DocumentContext = {
-			resolveReference(ref: string, base: string) {
+			resolveReference: () => undefined,
+			// resolveReference(ref: string, base: string) {
 
-				const isUri = base.indexOf('://') >= 0;
-				const resolveResult = ts.resolveModuleName(
-					ref,
-					isUri ? shared.uriToFsPath(base) : base,
-					vueLsHost.getCompilationSettings(),
-					compilerHost,
-				);
-				const failedLookupLocations: string[] = (resolveResult as any).failedLookupLocations;
-				const dirs = new Set<string>();
+			// 	const isUri = base.indexOf('://') >= 0;
+			// 	const resolveResult = ts.resolveModuleName(
+			// 		ref,
+			// 		isUri ? shared.uriToFsPath(base) : base,
+			// 		vueLsHost.getCompilationSettings(),
+			// 		compilerHost,
+			// 	);
+			// 	const failedLookupLocations: string[] = (resolveResult as any).failedLookupLocations;
+			// 	const dirs = new Set<string>();
 
-				const fileExists = vueLsHost.fileExists ?? ts.sys.fileExists;
-				const directoryExists = vueLsHost.directoryExists ?? ts.sys.directoryExists;
+			// 	const fileExists = vueLsHost.fileExists ?? ts.sys.fileExists;
+			// 	const directoryExists = vueLsHost.directoryExists ?? ts.sys.directoryExists;
 
-				for (const failed of failedLookupLocations) {
-					let path = failed;
-					const fileName = upath.basename(path);
-					if (fileName === 'index.d.ts' || fileName === '*.d.ts') {
-						dirs.add(upath.dirname(path));
-					}
-					if (path.endsWith('.d.ts')) {
-						path = upath.removeExt(upath.removeExt(path, '.ts'), '.d');
-					}
-					else {
-						continue;
-					}
-					if (fileExists(path)) {
-						return isUri ? shared.fsPathToUri(path) : path;
-					}
-				}
-				for (const dir of dirs) {
-					if (directoryExists(dir)) {
-						return isUri ? shared.fsPathToUri(dir) : dir;
-					}
-				}
+			// 	for (const failed of failedLookupLocations) {
+			// 		let path = failed;
+			// 		const fileName = upath.basename(path);
+			// 		if (fileName === 'index.d.ts' || fileName === '*.d.ts') {
+			// 			dirs.add(upath.dirname(path));
+			// 		}
+			// 		if (path.endsWith('.d.ts')) {
+			// 			path = upath.removeExt(upath.removeExt(path, '.ts'), '.d');
+			// 		}
+			// 		else {
+			// 			continue;
+			// 		}
+			// 		if (fileExists(path)) {
+			// 			return isUri ? shared.fsPathToUri(path) : path;
+			// 		}
+			// 	}
+			// 	for (const dir of dirs) {
+			// 		if (directoryExists(dir)) {
+			// 			return isUri ? shared.fsPathToUri(dir) : dir;
+			// 		}
+			// 	}
 
-				return undefined;
-			},
+			// 	return undefined;
+			// },
 		};
 		return documentContext;
 	}
 	function getTextDocument(uri: string) {
 
-		const fileName = shared.uriToFsPath(uri);
-		const scriptSnapshot = vueLsHost.getScriptSnapshot(fileName);
+		const scriptSnapshot = vueLsHost.getScriptSnapshot(uri);
 
 		if (scriptSnapshot) {
 

--- a/packages/vue-language-service/src/stylesheetExtra.ts
+++ b/packages/vue-language-service/src/stylesheetExtra.ts
@@ -49,7 +49,7 @@ export function createStylesheetExtra(cssPlugin: ReturnType<typeof useCssPlugin>
 
         if (!document) {
             document = TextDocument.create(
-                shared.fsPathToUri(embeddedFile.fileName),
+                embeddedFile.fileName,
                 shared.syntaxToLanguageId(embeddedFile.lang),
                 0,
                 embeddedFile.content,

--- a/packages/vue-language-service/src/utils/sharedLs.ts
+++ b/packages/vue-language-service/src/utils/sharedLs.ts
@@ -1,4 +1,3 @@
-import * as shared from '@volar/shared';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type * as ts2 from '@volar/typescript-language-service';
 
@@ -18,9 +17,9 @@ export function getDummyTsLs(
 			getProjectVersion: () => dummyProjectVersion.toString(),
 			getScriptVersion: () => dummyProjectVersion.toString(),
 			getCompilationSettings: () => ({ allowJs: true, jsx: ts.JsxEmit.Preserve }),
-			getScriptFileNames: () => [shared.uriToFsPath(doc.uri)],
-			getScriptSnapshot: fileName => {
-				if (shared.fsPathToUri(fileName) === shared.normalizeUri(doc.uri)) {
+			getScriptFileNames: () => [doc.uri],
+			getScriptSnapshot: uri => {
+				if (uri === doc.uri) {
 					return ts.ScriptSnapshot.fromString(doc.getText());
 				}
 			},

--- a/packages/vue-language-service/src/vueDocuments.ts
+++ b/packages/vue-language-service/src/vueDocuments.ts
@@ -143,8 +143,7 @@ export function parseVueDocuments(vueFiles: VueFiles) {
         getAll: untrack(getAll),
         get: untrack((uri: string) => {
 
-            const fileName = shared.uriToFsPath(uri);
-            const vueFile = vueFiles.get(fileName);
+            const vueFile = vueFiles.get(uri);
 
             if (vueFile) {
                 return vueDocuments.get(vueFile);
@@ -212,7 +211,7 @@ export function parseVueDocument(vueFile: VueFile) {
     // cache map
     const embeddedDocumentsMap = useCacheMap<EmbeddedFile, TextDocument>(embeddedFile => {
         return TextDocument.create(
-            shared.fsPathToUri(embeddedFile.fileName),
+            embeddedFile.fileName,
             shared.syntaxToLanguageId(embeddedFile.lang),
             0,
             embeddedFile.content,
@@ -228,7 +227,7 @@ export function parseVueDocument(vueFile: VueFile) {
     });
 
     // reactivity
-    const document = computed(() => TextDocument.create(shared.fsPathToUri(vueFile.fileName), 'vue', 0, vueFile.refs.content.value));
+    const document = computed(() => TextDocument.create(vueFile.fileName, 'vue', 0, vueFile.refs.content.value));
     const sourceMaps = computed(() => {
         return vueFile.refs.allEmbeddeds.value.map(embedded => sourceMapsMap.get(embedded));
     });
@@ -245,7 +244,7 @@ export function parseVueDocument(vueFile: VueFile) {
     });
 
     return {
-        uri: shared.fsPathToUri(vueFile.fileName),
+        uri: vueFile.fileName,
         file: vueFile,
         embeddedDocumentsMap,
         sourceMapsMap,

--- a/packages/vue-language-service/src/vuePlugins/autoCompleteRefs.ts
+++ b/packages/vue-language-service/src/vuePlugins/autoCompleteRefs.ts
@@ -1,6 +1,5 @@
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import * as vscode from 'vscode-languageserver-protocol';
-import * as shared from '@volar/shared';
 import * as ts2 from '@volar/typescript-language-service';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 import { hyphenate } from '@vue/shared';
@@ -43,7 +42,7 @@ export default function (host: {
 	function getAst(tsDoc: TextDocument) {
 		let ast = asts.get(tsDoc);
 		if (!ast) {
-			ast = host.ts.createSourceFile(shared.uriToFsPath(tsDoc.uri), tsDoc.getText(), host.ts.ScriptTarget.Latest);
+			ast = host.ts.createSourceFile(tsDoc.uri, tsDoc.getText(), host.ts.ScriptTarget.Latest);
 			asts.set(tsDoc, ast);
 		}
 		return ast;

--- a/packages/vue-language-service/src/vuePlugins/scriptSetupConversions.ts
+++ b/packages/vue-language-service/src/vuePlugins/scriptSetupConversions.ts
@@ -122,7 +122,7 @@ async function useSetupSugar(
 
     if (edits?.length) {
 
-        await context.applyEdit({ changes: { [vueDocument.uri]: edits } });
+        await context.applyEdit({ changes: { [vueDocument.file.fileName]: edits } });
         await shared.sleep(200);
 
         const importEdits = await getAddMissingImportsEdits(vueDocument, doCodeActions, doCodeActionResolve);

--- a/packages/vue-language-service/src/vuePlugins/vue.ts
+++ b/packages/vue-language-service/src/vuePlugins/vue.ts
@@ -125,7 +125,7 @@ export default function (host: Omit<Parameters<typeof useHtmlPlugin>[0], 'getHtm
                     }
                 }
 
-                if (host.scriptTsLs && !host.scriptTsLs.__internal__.isValidFile(vueDocument.file.getScriptTsFile().fileName)) {
+                if (host.scriptTsLs && !host.scriptTsLs.__internal__.isValidScript(vueDocument.file.getScriptTsFile().fileName)) {
                     for (const script of [sfc.script, sfc.scriptSetup]) {
 
                         if (!script || script.content === '')

--- a/packages/vue-language-service/src/vuePlugins/vueTemplateLanguage.ts
+++ b/packages/vue-language-service/src/vuePlugins/vueTemplateLanguage.ts
@@ -1,4 +1,3 @@
-import * as shared from '@volar/shared';
 import { parseScriptRanges } from '@volar/vue-code-gen/out/parsers/scriptRanges';
 import { SearchTexts, TypeScriptRuntime } from '@volar/vue-typescript';
 import { VueDocument, VueDocuments } from '../vueDocuments';
@@ -299,8 +298,7 @@ export default function <T extends ReturnType<typeof useHtmlPlugin>>(host: {
             return item;
 
         const vueDocument = _vueDocument;
-        const importFile = shared.uriToFsPath(data.importUri);
-        const rPath = path.relative(host.vueLsHost.getCurrentDirectory(), importFile);
+        const rPath = path.relative(host.vueLsHost.getCurrentDirectory(), data.importUri);
         const descriptor = vueDocument.file.getDescriptor();
         const scriptAst = vueDocument.file.getScriptAst();
         const scriptSetupAst = vueDocument.file.getScriptSetupAst();
@@ -406,12 +404,12 @@ export default function <T extends ReturnType<typeof useHtmlPlugin>>(host: {
         async function planAInsertText() {
             const embeddedScriptFile = vueDocument.file.getScriptTsFile();
             const embeddedScriptDocument = vueDocument.embeddedDocumentsMap.get(embeddedScriptFile);
-            const tsImportName = camelize(path.basename(importFile).replace(/\./g, '-'));
+            const tsImportName = camelize(path.basename(data.importUri).replace(/\./g, '-'));
             const [formatOptions, preferences] = await Promise.all([
                 host.tsSettings.getFormatOptions?.(embeddedScriptDocument) ?? {},
                 host.tsSettings.getPreferences?.(embeddedScriptDocument) ?? {},
             ]);
-            const tsDetail = host.scriptTsLs.__internal__.raw.getCompletionEntryDetails(shared.uriToFsPath(embeddedScriptDocument.uri), 0, tsImportName, formatOptions, importFile, preferences, undefined);
+            const tsDetail = host.scriptTsLs.__internal__.raw.getCompletionEntryDetails(embeddedScriptDocument.uri, 0, tsImportName, formatOptions, data.importUri, preferences, undefined);
             if (tsDetail?.codeActions) {
                 for (const action of tsDetail.codeActions) {
                     for (const change of action.changes) {
@@ -441,7 +439,7 @@ export default function <T extends ReturnType<typeof useHtmlPlugin>>(host: {
 
     async function provideHtmlData(vueDocument: VueDocument) {
 
-        const nameCases = await host.getNameCases?.(vueDocument.uri) ?? {
+        const nameCases = await host.getNameCases?.(vueDocument.file.fileName) ?? {
             tag: 'both',
             attr: 'kebabCase',
         };
@@ -637,8 +635,7 @@ export default function <T extends ReturnType<typeof useHtmlPlugin>>(host: {
             if (itemId?.type === 'importFile') {
 
                 const [fileUri] = itemId.args;
-                const filePath = shared.uriToFsPath(fileUri);
-                const rPath = path.relative(host.vueLsHost.getCurrentDirectory(), filePath);
+                const rPath = path.relative(host.vueLsHost.getCurrentDirectory(), fileUri);
                 const data: AutoImportCompletionData = {
                     mode: 'autoImport',
                     vueDocumentUri: vueDocument.uri,

--- a/packages/vue-typescript/src/utils/ts.ts
+++ b/packages/vue-typescript/src/utils/ts.ts
@@ -91,10 +91,11 @@ export function createParsedCommandLine(
 	}
 } {
 
-	const tsConfigPath = ts.sys.resolvePath(tsConfig);
+	const tsConfigPath = ts.sys.resolvePath(tsConfig.replace('file://', ''));
 	const config = ts.readJsonConfigFile(tsConfigPath, ts.sys.readFile);
 	const content = ts.parseJsonSourceFileConfigFileContent(config, parseConfigHost, path.dirname(tsConfigPath), {}, path.basename(tsConfigPath));
 	content.options.outDir = undefined; // TODO: patching ts server broke with outDir + rootDir + composite/incremental
+	content.fileNames = content.fileNames.map(fileName => 'file://' + fileName);
 
 	let baseVueOptions = {};
 	const folder = path.dirname(tsConfig);


### PR DESCRIPTION
Use uri instead of fsPath for entire project, not sure if it's possible, if it can it would be a huge improvement.

The current obstacle is the need to adjust the resolveModuleNames of the typescript language service.