### PR TITLE
remove "volar.formatting.printWidth" setting

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -300,11 +300,6 @@
 					"default": false,
 					"description": "[pug ☐] code lens."
 				},
-				"volar.formatting.printWidth": {
-					"type": "number",
-					"default": 100,
-					"description": "HTML formatting print width."
-				},
 				"volar.icon.splitEditors": {
 					"type": "boolean",
 					"default": true,


### PR DESCRIPTION
`volar.formatting.printWidth` settings have been removed as they are no longer needed. <https://github.com/johnsoncodehk/volar/commit/54bd09578f6f8adf95d5dd587d395a1f8b858d60>