### PR TITLE
add option to set `--max-old-space-size` on server

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -270,6 +270,14 @@
 					"default": false,
 					"description": "Use second server to progress heavy diagnostic works, the main server workhorse computing intellisense, operations such as auto-complete can respond faster. Note that this will lead to more memory usage."
 				},
+				"volar.vueserver.maxOldSpaceSize": {
+					"type": [
+						"number",
+						"null"
+					],
+					"default": null,
+					"description": "Set --max-old-space-size option on server process. If you have problem on frequently \"Request textDocument/** failed.\" error, try setting higher memory(MB) on it."
+				},
 				"volar.codeLens.references": {
 					"type": "boolean",
 					"default": true,

--- a/extensions/vscode-vue-language-features/src/nodeClientMain.ts
+++ b/extensions/vscode-vue-language-features/src/nodeClientMain.ts
@@ -12,9 +12,18 @@ export function activate(context: vscode.ExtensionContext) {
 	) => {
 
 		const serverModule = vscode.Uri.joinPath(context.extensionUri, 'server');
+		const maxOldSpaceSize = vscode.workspace.getConfiguration('volar').get<number | null>('vueserver.maxOldSpaceSize');
+		const runOptions = { execArgv: <string[]>[] };
+		if (maxOldSpaceSize) {
+			runOptions.execArgv.push("--max-old-space-size=" + maxOldSpaceSize);
+		}
 		const debugOptions = { execArgv: ['--nolazy', '--inspect=' + port] };
 		const serverOptions: lsp.ServerOptions = {
-			run: { module: serverModule.fsPath, transport: lsp.TransportKind.ipc },
+			run: {
+				module: serverModule.fsPath,
+				transport: lsp.TransportKind.ipc,
+				options: runOptions
+			},
 			debug: {
 				module: serverModule.fsPath,
 				transport: lsp.TransportKind.ipc,


### PR DESCRIPTION
It's a workaround to solved `JavaScript heap out of memory`

## Motivation

I have problem on `JavaScript heap out of memory`. I found many related issues but many of them closed by lack of info to repro
- https://github.com/johnsoncodehk/volar/issues/862
- https://github.com/johnsoncodehk/volar/issues/658#issuecomment-1014084522
- https://github.com/johnsoncodehk/volar/issues/1242#issuecomment-1114579455
- https://github.com/johnsoncodehk/volar/issues/514
- https://github.com/johnsoncodehk/volar/issues/1025
- https://github.com/johnsoncodehk/volar/issues/1106
```sh
$ echo "In my case"
$ NODE_OPTIONS='--max_old_space_size=700' npx vue-tsc --noEmit 
<--- Last few GCs --->

[12514:0x56b6af0]    26053 ms: Mark-sweep (reduce) 698.3 (711.3) -> 697.3 (711.1) MB, 220.5 / 0.0 ms  (average mu = 0.167, current mu = 0.156) allocation failure scavenge might not succeed
[12514:0x56b6af0]    26105 ms: Scavenge (reduce) 698.4 (711.1) -> 697.7 (711.1) MB, 5.2 / 0.0 ms  (average mu = 0.167, current mu = 0.156) allocation failure 


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
...
```

I tried the solutions:
1. Turn on `volar.lowPowerMode`: failed
2. Use take over mode: failed
3. Remove Vetur: failed
4. Set `--max-old-space-size=6144` on server: success
