### PR TITLE
Show experimentalCompatMode Info

### DIFF
--- a/extensions/vscode-vue-language-features/src/features/doctor.ts
+++ b/extensions/vscode-vue-language-features/src/features/doctor.ts
@@ -2,6 +2,7 @@ import { getCurrentTsPaths } from './tsVersion';
 import * as vscode from 'vscode';
 import * as shared from '@volar/shared';
 import { takeOverModeEnabled } from '../common';
+import * as fs from 'fs'
 
 export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('volar.action.doctor', async () => {
@@ -15,22 +16,31 @@ export async function activate(context: vscode.ExtensionContext) {
 			)
 		}
 
+		let experimentalCompatMode = undefined
+		const tsConfigPaths = await vscode.workspace.findFiles('tsconfig.json')
+		if (tsConfigPaths.length > 0) {
+			const data = fs.readFileSync(tsConfigPaths[0].fsPath, 'utf8')
+			const tsConfig = JSON.parse(data)
+			experimentalCompatMode = tsConfig.vueCompilerOptions?.experimentalCompatMode
+		}
+
 		const tsPaths = getCurrentTsPaths(context);
 		const tsVersion = shared.getTypeScriptVersion(tsPaths.serverPath);
 		const content = `
 ## Infos
 
-vscode.version: ${vscode.version}
-vscode.typescript.version: ${tsVersion}
-vscode.typescript-extension.actived: ${!!vscode.extensions.getExtension('vscode.typescript-language-features')}
-vue-language-features.version: ${context.extension.packageJSON.version}
-typescript-vue-plugin.version: ${vscode.extensions.getExtension('Vue.vscode-typescript-vue-plugin')?.packageJSON.version}
-vetur.actived: ${!!vetur}
-workspace.vue-tsc.version: ${getWorkspacePackageJson('vue-tsc')?.version}
-workspace.typescript.version: ${getWorkspacePackageJson('typescript')?.version}
-workspace.vue.version: ${getWorkspacePackageJson('vue')?.version}
-workspace.@vue/runtime-dom.version: ${getWorkspacePackageJson('@vue/runtime-dom')?.version}
-takeover-mode.enabled: ${takeOverModeEnabled()}
+- vscode.version: ${vscode.version}
+- vscode.typescript.version: ${tsVersion}
+- vscode.typescript-extension.actived: ${!!vscode.extensions.getExtension('vscode.typescript-language-features')}
+- vue-language-features.version: ${context.extension.packageJSON.version}
+- typescript-vue-plugin.version: ${vscode.extensions.getExtension('Vue.vscode-typescript-vue-plugin')?.packageJSON.version}
+- vetur.actived: ${!!vetur}
+- workspace.vue-tsc.version: ${getWorkspacePackageJson('vue-tsc')?.version}
+- workspace.typescript.version: ${getWorkspacePackageJson('typescript')?.version}
+- workspace.vue.version: ${getWorkspacePackageJson('vue')?.version}
+- workspace.@vue/runtime-dom.version: ${getWorkspacePackageJson('@vue/runtime-dom')?.version}
+- workspace.tsconfig.experimentalCompatMode: ${experimentalCompatMode}
+- takeover-mode.enabled: ${takeOverModeEnabled()}
 
 ### Configuration
 


### PR DESCRIPTION
Check tsconfig for "expermentalCompatMode".
Also format infos into markdown list.

This fixes third point of https://github.com/johnsoncodehk/volar/issues/1254.