### PR TITLE
Add a Vite problem matcher to the VS Code extension

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -638,7 +638,21 @@
 					"group": "navigation"
 				}
 			]
-		}
+		},
+		"problemMatchers": [
+			{
+				"name": "vite",
+				"label": "Vite problems",
+				"pattern": {
+					"regexp": ""
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": "restarting server...$",
+					"endsPattern": "^\\s*ready in"
+				}
+			}
+		]
 	},
 	"scripts": {
 		"prebuild": "cd ../.. && npm run build",


### PR DESCRIPTION
Vite doesn't really print build errors to the terminal AFAIK, this is for the background patterns that will allow to properly set a vite task as `isBackground`, and to properly use it in `preLaunchTask` in launch configurations.
