### PR TITLE
fix: fix build error in windows

### DIFF
--- a/extensions/vscode-vue-language-features/scripts/build-node.js
+++ b/extensions/vscode-vue-language-features/scripts/build-node.js
@@ -21,7 +21,8 @@ require('esbuild').build({
             setup(build) {
                 build.onResolve({ filter: /^(vscode-.*|estree-walker|jsonc-parser)/ }, args => {
                     const pathUmdMay = require.resolve(args.path, { paths: [args.resolveDir] })
-                    const pathEsm = pathUmdMay.replace('/umd/', '/esm/')
+										// Call twice the replace is to solve the problem of the path in Windows
+                    const pathEsm = pathUmdMay.replace('/umd/', '/esm/').replace('\\umd\\', '\\esm\\')
                     return { path: pathEsm }
                 })
                 build.onResolve({ filter: /^\@vue\/compiler-sfc$/ }, args => {


### PR DESCRIPTION
Because the path split sign under window is `\` so there will be a bug when use windows to build
Can not replace `/umd/` to `/esm/` in windows
![image](https://user-images.githubusercontent.com/38457491/170458463-cbb1c6c7-a8c7-4ef4-9b08-a6a23bf0c69b.png)
