### PR TITLE
feat(vue-tsc): support tracing

### DIFF
--- a/packages/vue-tsc/bin/vue-tsc.js
+++ b/packages/vue-tsc/bin/vue-tsc.js
@@ -32,6 +32,18 @@ fs.readFileSync = (...args) => {
             `function createProgram(rootNamesOrOptions, _options, _host, _oldProgram, _configFileParsingDiagnostics) {`,
             `function createProgram(rootNamesOrOptions, _options, _host, _oldProgram, _configFileParsingDiagnostics) { return require(${JSON.stringify(proxyPath)}).createProgramProxy(...arguments);`,
         );
+
+        // proxy tracing
+        tsc = tsc.replace(
+            `ts.startTracing = tracingEnabled.startTracing;`,
+            `ts.startTracing = require("typescript/lib/tsserverlibrary").startTracing;`,
+        );
+
+        tsc = tsc.replace(
+            `ts.dumpTracingLegend = tracingEnabled.dumpLegend;`,
+            `ts.dumpTracingLegend = require("typescript/lib/tsserverlibrary").dumpTracingLegend;`,
+        );
+
         return tsc;
     }
     return readFileSync(...args);


### PR DESCRIPTION
Proxy tracing API to `tsserverlibrary`

fixes: #1375