### PR TITLE
fix: direct execution of vue.findAllFileReferences command

### DIFF
--- a/extensions/vscode-vue-language-features/src/features/fileReferences.ts
+++ b/extensions/vscode-vue-language-features/src/features/fileReferences.ts
@@ -6,13 +6,20 @@ import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 export async function register(context: vscode.ExtensionContext, client: BaseLanguageClient) {
-	vscode.commands.registerCommand('vue.findAllFileReferences', async (uri: vscode.Uri) => {
+	vscode.commands.registerCommand('vue.findAllFileReferences', async (uri?: vscode.Uri) => {
 
 		// https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/fileReferences.ts
 		await vscode.window.withProgress({
 			location: vscode.ProgressLocation.Window,
 			title: localize('progress.title', "Finding file references")
 		}, async (_progress, token) => {
+
+      			if (!uri) {
+      			  const editor = vscode.window.activeTextEditor;
+      			  if (!editor) return;
+
+      			  uri = editor.document.uri;
+      			}
 
 			const response = await client.sendRequest(shared.FindFileReferenceRequest.type, { textDocument: { uri: uri.toString() } });
 			if (!response) {


### PR DESCRIPTION
## Description

Error when executed directly from command.

<img width="958" alt="findAllFileReferences-command" src="https://user-images.githubusercontent.com/188642/172529694-70d9ea66-bb4d-4d60-9f0d-215031334539.png">

## Fixed (mp4)

https://user-images.githubusercontent.com/188642/172530126-2fb270ca-d88a-48c0-a9ad-f92088ed676e.mp4
