### PR TITLE
fix: css classes parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 *VSCode extension to support Vue in TS server*
 - [vue-tsc](https://github.com/johnsoncodehk/volar/tree/master/packages/vue-tsc) \
 *Type-check and dts build command line tool*
+- [vite-plugin-vue-component-preview](https://github.com/johnsoncodehk/vite-plugin-vue-component-preview) \
+*Vite plugin for support Vue component preview view with `Vue Language Features`*
 
 ### Alpine.js
 

--- a/packages/vue-typescript/src/utils/parseCssClassNames.ts
+++ b/packages/vue-typescript/src/utils/parseCssClassNames.ts
@@ -2,11 +2,11 @@ import { clearComments } from './parseCssVars';
 
 export function* parseCssClassNames(styleContent: string) {
 	styleContent = clearComments(styleContent);
-	const cssClassNameRegex = /\.([\w-]+)/g;
+	const cssClassNameRegex = /(?=[\.]{1}([a-zA-Z_]+[\w\_\-]*)[\s\.\+\{\>#\:]{1})/g;
 	const matchs = styleContent.matchAll(cssClassNameRegex);
 	for (const match of matchs) {
 		if (match.index !== undefined) {
-			const matchText = match[0];
+			const matchText = match[1];
 			if (matchText !== undefined) {
 				yield { start: match.index, end: match.index + matchText.length };
 			}

--- a/packages/vue-typescript/src/utils/parseCssClassNames.ts
+++ b/packages/vue-typescript/src/utils/parseCssClassNames.ts
@@ -2,7 +2,7 @@ import { clearComments } from './parseCssVars';
 
 export function* parseCssClassNames(styleContent: string) {
 	styleContent = clearComments(styleContent);
-	const cssClassNameRegex = /(?=[\.]{1}([a-zA-Z_]+[\w\_\-]*)[\s\.\+\{\>#\:]{1})/g;
+	const cssClassNameRegex = /(?=([\.]{1}[a-zA-Z_]+[\w\_\-]*)[\s\.\+\{\>#\:]{1})/g;
 	const matchs = styleContent.matchAll(cssClassNameRegex);
 	for (const match of matchs) {
 		if (match.index !== undefined) {


### PR DESCRIPTION
Closes #1481  

Fixes an issue when parsing css classes when css contains "." character that are not class selectors (example `1.5em` or when using scss modules syntax).

