### PR TITLE
Push binding if importClause if default export

### DIFF
--- a/packages/vue-code-gen/src/parsers/scriptSetupRanges.ts
+++ b/packages/vue-code-gen/src/parsers/scriptSetupRanges.ts
@@ -159,7 +159,7 @@ export function parseBindingRanges(ts: typeof import('typescript/lib/tsserverlib
 
 		if (ts.isImportDeclaration(node)) {
 			if (node.importClause && (isType || !node.importClause.isTypeOnly)) {
-				if (node.importClause.name && !isType) {
+				if (node.importClause.name) {
 					bindings.push(_getStartEnd(node.importClause.name));
 				}
 				if (node.importClause.namedBindings) {


### PR DESCRIPTION
Fixes https://github.com/johnsoncodehk/volar/issues/1524

If importClause is default export binding won't be added. 
@johnsoncodehk pls review because i dont know if this break anything. Tests are running fine.