### PR TITLE
extend editor.defaultFormatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,14 @@
 	"editor.insertSpaces": false,
 	"editor.detectIndentation": false,
 	"typescript.tsdk": "node_modules/typescript/lib",
-	"editor.defaultFormatter": "vscode.typescript-language-features"
+	"editor.defaultFormatter": "vscode.typescript-language-features",
+	"[typescript]": {
+		"editor.defaultFormatter": "vscode.typescript-language-features"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "vscode.json-language-features"
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "vscode.typescript-language-features"
+	}
 }


### PR DESCRIPTION
Follow up of https://github.com/johnsoncodehk/volar/issues/1512

Only adding "editor.defaultFormatter" in vscode settings didn't work  for me. My VSCode was still using prettier.
When adding "editor.defaultFormatter" with specific languages it works.