### PR TITLE
Fix takeOverMode auto type

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -349,7 +349,10 @@
 					"description": "Auto-complete Ref value with `.value`."
 				},
 				"volar.takeOverMode.enabled": {
-					"type": "boolean",
+					"type": [
+						"boolean",
+						"string"
+					],
 					"enum": [
 						"auto",
 						true,


### PR DESCRIPTION
This PR aims to fix the type of `volar.takeOverMode.enabled` when its sets to `auto`.

![image](https://user-images.githubusercontent.com/35312043/179423176-570e6c42-29d8-4579-b2aa-0867fbcd5b88.png)