### PR TITLE
fix: wrong check for whether jsx option is set

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,6 +65,7 @@ In order to support Vue 2 templates you need to edit your `tsconfig.json` file
 ```jsonc{6}
 {
   "compilerOptions": {
+    "jsx": "preserve",
     // ...
   },
   "vueCompilerOptions": {

--- a/packages/vue-typescript/src/sourceFile.ts
+++ b/packages/vue-typescript/src/sourceFile.ts
@@ -529,7 +529,7 @@ export function createSourceFile(
 		getSfcRefSugarRanges: () => sfcRefSugarRanges.value,
 		getEmbeddeds: () => embeddeds.value,
 		getScriptSetupRanges: () => scriptSetupRanges.value,
-		isJsxMissing: () => !vueCompilerOptions.experimentalDisableTemplateSupport && (compilerOptions.jsx ?? ts.JsxEmit.Preserve) !== ts.JsxEmit.Preserve,
+		isJsxMissing: () => !vueCompilerOptions.experimentalDisableTemplateSupport && compilerOptions.jsx !== ts.JsxEmit.Preserve,
 
 		getAllEmbeddeds: () => allEmbeddeds.value,
 		getTeleports: () => teleports.value,

--- a/packages/vue-typescript/src/sourceFile.ts
+++ b/packages/vue-typescript/src/sourceFile.ts
@@ -258,7 +258,7 @@ export function createSourceFile(
 			scriptSetupRanges,
 			scriptLang,
 			vueCompilerOptions,
-			!!vueCompilerOptions.experimentalDisableTemplateSupport || (compilerOptions.jsx ?? ts.JsxEmit.Preserve) !== ts.JsxEmit.Preserve,
+			!!vueCompilerOptions.experimentalDisableTemplateSupport || compilerOptions.jsx !== ts.JsxEmit.Preserve,
 			fileName.endsWith('.html') // petite-vue
 		),
 	];


### PR DESCRIPTION
The old logic `(compilerOptions.jsx ?? ts.JsxEmit.Preserve) !== ts.JsxEmit.Preserve` didn't seem right in case the `compilerOptions.jsx` was not set as then it assumed that the default value is `preserve` and thus that the resolved value is also `preserve`. That would result in no diagnostic from https://github.com/johnsoncodehk/volar/blob/a77cc83c9f6ac0ff4fdab9989fa9eceadc844a86/packages/vue-language-service/src/plugins/vue.ts#L152-L165 being created.

Maybe this had to do with a change in 4e6f6f77c589e39c1139a323fa75a7633eceadc4 where the real, evaluated options were checked? Not sure.