### PR TITLE
fix: update default value in schema

### DIFF
--- a/extensions/vscode-vue-language-features/schemas/vue-tsconfig.schema.json
+++ b/extensions/vscode-vue-language-features/schemas/vue-tsconfig.schema.json
@@ -50,7 +50,7 @@
 						false,
 						"onlyJs"
 					],
-					"default": false,
+					"default": "onlyJs",
 					"markdownDescription": "Implicit wrap object literal component options export with `Vue.extend()`."
 				},
 				"experimentalDowngradePropsAndEmitsToSetupReturnOnScriptSetup": {


### PR DESCRIPTION
According to the code the default value of `experimentalImplicitWrapComponentOptionsWithVue2Extend` is `onlyJs`:
https://github.com/johnsoncodehk/volar/blob/834a8668bb75e7ce9f5da4b3ea8c9200d60ee04a/packages/vue-typescript/src/plugins/vue-typescript-scripts.ts#L36-L36