### PR TITLE
feat(component-meta): allow documenting components in .ts files

### DIFF
--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -133,13 +133,10 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 		useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
 		getCompilationSettings: () => parsedCommandLine.options,
 		getScriptFileNames: () => {
-			const result = [...parsedCommandLine.fileNames];
-			for (const fileName of parsedCommandLine.fileNames) {
-				if (fileName.endsWith('.vue')) {
-					result.push(fileName + '.meta.ts');
-				}
-			}
-			return result;
+			return [
+				...parsedCommandLine.fileNames,
+				...parsedCommandLine.fileNames.map(getMetaFileName),
+			];
 		},
 		getProjectReferences: () => parsedCommandLine.projectReferences,
 		getScriptVersion: (fileName) => '0',
@@ -163,6 +160,10 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 		getComponentMeta,
 	};
 
+	function getMetaFileName(fileName: string) {
+		return (fileName.endsWith('.vue') ? fileName : fileName.substring(0, fileName.lastIndexOf('.'))) + '.meta.ts';
+	}
+
 	function getMetaScriptContent(fileName: string) {
 		return `
 			import Component from '${fileName.substring(0, fileName.length - '.meta.ts'.length)}';
@@ -172,7 +173,7 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 
 	function getComponentMeta(componentPath: string) {
 
-		const sourceFile = program?.getSourceFile(componentPath + '.meta.ts');
+		const sourceFile = program?.getSourceFile(getMetaFileName(componentPath));
 		if (!sourceFile) {
 			throw 'Could not find main source file';
 		}

--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -87,11 +87,12 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 		const symbolType = typeChecker.getTypeAtLocation(symbolNode);
 		const symbolProperties = symbolType.getProperties();
 
-		return {
+		return [{
+			name: 'default',
 			props: getProps(),
 			events: getEvents(),
 			slots: getSlots(),
-		};
+		}];
 
 		function getProps() {
 

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -370,23 +370,19 @@ describe(`vue-component-meta`, () => {
 	test('ts-component', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/ts-component/component.ts');
-		const metaList = checker.getComponentMeta(componentPath);
-
-		expect(metaList).toEqual(expect.arrayContaining([]));
-
-		const meta = metaList.find(m => m.name === 'default') || { props: [] };
+		const meta = checker.getComponentMeta(componentPath);
 
 		const a = meta.props.find(prop =>
 			prop.name === 'foo'
-			&& prop.isOptional === false
+			&& prop.required === true
 			&& prop.type === 'string'
-			&& prop.documentationComment === 'string foo'
+			&& prop.description === 'string foo'
 		);
 		const b = meta.props.find(prop =>
 			prop.name === 'bar'
-			&& prop.isOptional === true
+			&& prop.required === false
 			&& prop.type === 'number | undefined'
-			&& prop.documentationComment === 'optional number bar'
+			&& prop.description === 'optional number bar'
 		);
 
 		expect(a).toBeDefined();

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -367,28 +367,6 @@ describe(`vue-component-meta`, () => {
 		expect(b).toBeDefined();
 	});
 
-	test('ts-component', () => {
-
-		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/ts-component/component.ts');
-		const meta = checker.getComponentMeta(componentPath);
-
-		const a = meta.props.find(prop =>
-			prop.name === 'foo'
-			&& prop.required === true
-			&& prop.type === 'string'
-			&& prop.description === 'string foo'
-		);
-		const b = meta.props.find(prop =>
-			prop.name === 'bar'
-			&& prop.required === false
-			&& prop.type === 'number | undefined'
-			&& prop.description === 'optional number bar'
-		);
-
-		expect(a).toBeDefined();
-		expect(b).toBeDefined();
-	});
-
 	test('exposed', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-exposed/component.vue');
@@ -401,5 +379,26 @@ describe(`vue-component-meta`, () => {
 		);
 
 		expect(counter).toBeDefined();
+	});
+
+	test('ts-named-exports', () => {
+
+		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/ts-named-export/component.ts');
+		const Foo = checker.getComponentMeta(componentPath, 'Foo');
+		const Bar = checker.getComponentMeta(componentPath, 'Bar');
+
+		const a = Foo.props.find(prop =>
+			prop.name === 'foo'
+			&& prop.required === true
+			&& prop.type === 'string'
+		);
+		const b = Bar.props.find(prop =>
+			prop.name === 'bar'
+			&& prop.required === false
+			&& prop.type === 'number | undefined'
+		);
+
+		expect(a).toBeDefined();
+		expect(b).toBeDefined();
 	});
 });

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -384,8 +384,11 @@ describe(`vue-component-meta`, () => {
 	test('ts-named-exports', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/ts-named-export/component.ts');
+		const exportNames = checker.getExportNames(componentPath);
 		const Foo = checker.getComponentMeta(componentPath, 'Foo');
 		const Bar = checker.getComponentMeta(componentPath, 'Bar');
+
+		expect(exportNames).toEqual(['Foo', 'Bar']);
 
 		const a = Foo.props.find(prop =>
 			prop.name === 'foo'

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -1,13 +1,13 @@
 import * as path from 'path';
-import { describe, expect, it } from 'vitest';
-import * as metaChecker from '..';
+import { describe, expect, test } from 'vitest';
+import * as metaChecker from '../src/index';
 
 describe(`vue-component-meta`, () => {
 
 	const tsconfigPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/tsconfig.json');
 	const checker = metaChecker.createComponentMetaChecker(tsconfigPath);
 
-	it('reference-type-props', () => {
+	test('reference-type-props', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-props/component.vue');
 		const metaList = checker.getComponentMeta(componentPath);
@@ -33,7 +33,7 @@ describe(`vue-component-meta`, () => {
 		expect(b).toBeDefined();
 	});
 
-	it('reference-type-events', () => {
+	test('reference-type-events', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-events/component.vue');
 		const metaList = checker.getComponentMeta(componentPath);
@@ -72,7 +72,7 @@ describe(`vue-component-meta`, () => {
 		expect(c).toBeDefined();
 	});
 
-	it('template-slots', () => {
+	test('template-slots', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/template-slots/component.vue');
 		const metaList = checker.getComponentMeta(componentPath);
@@ -99,7 +99,7 @@ describe(`vue-component-meta`, () => {
 		expect(c).toBeDefined();
 	});
 
-	it('class-slots', () => {
+	test('class-slots', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/class-slots/component.vue');
 		const metaList = checker.getComponentMeta(componentPath);
@@ -115,6 +115,32 @@ describe(`vue-component-meta`, () => {
 		const b = meta.slots.find(slot =>
 			slot.name === 'foo'
 			&& slot.propsType === '{ str: string; }'
+		);
+
+		expect(a).toBeDefined();
+		expect(b).toBeDefined();
+	});
+
+	test('ts-component', () => {
+
+		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/ts-component/component.ts');
+		const metaList = checker.getComponentMeta(componentPath);
+
+		expect(metaList).toEqual(expect.arrayContaining([]));
+
+		const meta = metaList.find(m => m.name === 'default') || { props: [] };
+
+		const a = meta.props.find(prop =>
+			prop.name === 'foo'
+			&& prop.isOptional === false
+			&& prop.type === 'string'
+			&& prop.documentationComment === 'string foo'
+		);
+		const b = meta.props.find(prop =>
+			prop.name === 'bar'
+			&& prop.isOptional === true
+			&& prop.type === 'number | undefined'
+			&& prop.documentationComment === 'optional number bar'
 		);
 
 		expect(a).toBeDefined();

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -10,7 +10,11 @@ describe(`vue-component-meta`, () => {
 	it('reference-type-props', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-props/component.vue');
-		const meta = checker.getComponentMeta(componentPath);
+		const metaList = checker.getComponentMeta(componentPath);
+
+		expect(metaList).toEqual(expect.arrayContaining([]));
+
+		const meta = metaList.find(m => m.name === 'default') || { props: [] };
 
 		const a = meta.props.find(prop =>
 			prop.name === 'foo'
@@ -32,7 +36,11 @@ describe(`vue-component-meta`, () => {
 	it('reference-type-events', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-events/component.vue');
-		const meta = checker.getComponentMeta(componentPath);
+		const metaList = checker.getComponentMeta(componentPath);
+
+		expect(metaList).toEqual(expect.arrayContaining([]));
+
+		const meta = metaList.find(m => m.name === 'default') || { events: [] };
 
 		const a = meta.events.find(event =>
 			event.name === 'foo'
@@ -67,7 +75,11 @@ describe(`vue-component-meta`, () => {
 	it('template-slots', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/template-slots/component.vue');
-		const meta = checker.getComponentMeta(componentPath);
+		const metaList = checker.getComponentMeta(componentPath);
+
+		expect(metaList).toEqual(expect.arrayContaining([]));
+
+		const meta = metaList.find(m => m.name === 'default') || { slots: [] };
 
 		const a = meta.slots.find(slot =>
 			slot.name === 'default'
@@ -90,7 +102,11 @@ describe(`vue-component-meta`, () => {
 	it('class-slots', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/class-slots/component.vue');
-		const meta = checker.getComponentMeta(componentPath);
+		const metaList = checker.getComponentMeta(componentPath);
+
+		expect(metaList).toEqual(expect.arrayContaining([]));
+
+		const meta = metaList.find(m => m.name === 'default') || { slots: [] };
 
 		const a = meta.slots.find(slot =>
 			slot.name === 'default'

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import * as metaChecker from '..';
 
 describe(`vue-component-meta`, () => {
@@ -7,7 +7,7 @@ describe(`vue-component-meta`, () => {
 	const tsconfigPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/tsconfig.json');
 	const checker = metaChecker.createComponentMetaChecker(tsconfigPath);
 
-	it('reference-type-props', () => {
+	test('reference-type-props', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-props/component.vue');
 		const meta = checker.getComponentMeta(componentPath);
@@ -290,7 +290,7 @@ describe(`vue-component-meta`, () => {
 		});
 	});
 
-	it('reference-type-events', () => {
+	test('reference-type-events', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-events/component.vue');
 		const meta = checker.getComponentMeta(componentPath);
@@ -326,7 +326,7 @@ describe(`vue-component-meta`, () => {
 		expect(onBaz?.schema).toEqual([]);
 	});
 
-	it('template-slots', () => {
+	test('template-slots', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/template-slots/component.vue');
 		const meta = checker.getComponentMeta(componentPath);
@@ -349,7 +349,7 @@ describe(`vue-component-meta`, () => {
 		expect(c).toBeDefined();
 	});
 
-	it('class-slots', () => {
+	test('class-slots', () => {
 
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/class-slots/component.vue');
 		const meta = checker.getComponentMeta(componentPath);

--- a/packages/vue-test-workspace/vue-component-meta/ts-component/PropDefinitions.ts
+++ b/packages/vue-test-workspace/vue-component-meta/ts-component/PropDefinitions.ts
@@ -1,0 +1,10 @@
+export interface MyProps {
+	/**
+	 * string foo
+	 */
+	foo: string,
+	/**
+	 * optional number bar
+	 */
+	bar?: number,
+}

--- a/packages/vue-test-workspace/vue-component-meta/ts-component/component.ts
+++ b/packages/vue-test-workspace/vue-component-meta/ts-component/component.ts
@@ -1,0 +1,10 @@
+import { h } from "vue";
+import { MyProps } from "./PropDefinitions";
+
+export default {
+	setup(props: MyProps){
+		return () => {
+			h('pre', JSON.stringify(props, null, 2));
+		}
+	}
+}

--- a/packages/vue-test-workspace/vue-component-meta/ts-component/component.ts
+++ b/packages/vue-test-workspace/vue-component-meta/ts-component/component.ts
@@ -1,10 +1,6 @@
-import { h } from "vue";
+import { h, defineComponent } from "vue";
 import { MyProps } from "./PropDefinitions";
 
-export default {
-	setup(props: MyProps){
-		return () => {
-			h('pre', JSON.stringify(props, null, 2));
-		}
-	}
-}
+export default defineComponent((props: MyProps) => {
+	return h('pre', JSON.stringify(props, null, 2));
+});

--- a/packages/vue-test-workspace/vue-component-meta/ts-named-export/component.ts
+++ b/packages/vue-test-workspace/vue-component-meta/ts-named-export/component.ts
@@ -1,0 +1,5 @@
+import { defineComponent } from "vue";
+
+export const Foo = defineComponent((_: { foo: string; }) => { });
+
+export const Bar = defineComponent((_: { bar?: number; }) => { });


### PR DESCRIPTION
If you are library author and have a lot of components to maintain, using ts files is often simpler.

Check out bootstrap-vue or vuetify and see for yourself.

This allows for parsing components like:

```ts
export default defineComponent({
	setup(props: MyProps){
		return () => {
			h('pre', JSON.stringify(props, null, 2));
		}
	}
})
```

or even 

```tsx
export const MyFunctionalComponent = defineComponent((props: MyProps) => {
	<pre>{ JSON.stringify(props, null, 2) } </pre> 
})