### PR TITLE
feat(vue-component-meta): extract the "exposed" metadata

### DIFF
--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -272,7 +272,7 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 				return exposed.map(expose => ({
 					name: expose.escapedName as string,
 					type: typeChecker.typeToString(typeChecker.getTypeOfSymbolAtLocation(expose, symbolNode!)),
-					documentationComment: ts.displayPartsToString(expose.getDocumentationComment(typeChecker)),
+					description: ts.displayPartsToString(expose.getDocumentationComment(typeChecker)),
 				}));
 			}
 

--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -91,6 +91,7 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 			props: getProps(),
 			events: getEvents(),
 			slots: getSlots(),
+			exposed: getExposed(),
 		};
 
 		function getProps() {
@@ -150,6 +151,24 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 				}));
 			}
 
+			return [];
+		}
+
+		function getExposed() {
+	
+			const exposed = symbolProperties.filter(prop => 
+				// only exposed props will have a syntheticOrigin
+				Boolean((prop as any).syntheticOrigin)
+			)
+	
+			if (exposed.length) {
+				return exposed.map(expose => ({
+					name: expose.escapedName as string,
+					type: typeChecker.typeToString(typeChecker.getTypeOfSymbolAtLocation(expose, symbolNode!)),
+					documentationComment: ts.displayPartsToString(expose.getDocumentationComment(typeChecker)),
+				}));
+			}
+	
 			return [];
 		}
 	}

--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -262,12 +262,12 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 		}
 
 		function getExposed() {
-	
-			const exposed = symbolProperties.filter(prop => 
+
+			const exposed = symbolProperties.filter(prop =>
 				// only exposed props will have a syntheticOrigin
 				Boolean((prop as any).syntheticOrigin)
-			)
-	
+			);
+
 			if (exposed.length) {
 				return exposed.map(expose => ({
 					name: expose.escapedName as string,
@@ -275,7 +275,7 @@ export function createComponentMetaChecker(tsconfigPath: string) {
 					documentationComment: ts.displayPartsToString(expose.getDocumentationComment(typeChecker)),
 				}));
 			}
-	
+
 			return [];
 		}
 	}

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -375,7 +375,7 @@ describe(`vue-component-meta`, () => {
 		const counter = meta.exposed.find(exposed =>
 			exposed.name === 'counter'
 			&& exposed.type === 'string'
-			&& exposed.documentationComment === 'a counter string'
+			&& exposed.description === 'a counter string'
 		);
 
 		expect(counter).toBeDefined();

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -368,7 +368,7 @@ describe(`vue-component-meta`, () => {
 	});
 
 	test('exposed', () => {
-		
+
 		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-exposed/component.vue');
 		const meta = checker.getComponentMeta(componentPath);
 
@@ -379,5 +379,5 @@ describe(`vue-component-meta`, () => {
 		);
 
 		expect(counter).toBeDefined();
-	})
+	});
 });

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import * as metaChecker from '..';
 
 describe(`vue-component-meta`, () => {
@@ -104,4 +104,18 @@ describe(`vue-component-meta`, () => {
 		expect(a).toBeDefined();
 		expect(b).toBeDefined();
 	});
+
+	test('exposed', () => {
+		
+		const componentPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/reference-type-exposed/component.vue');
+		const meta = checker.getComponentMeta(componentPath);
+
+		const counter = meta.exposed.find(exposed =>
+			exposed.name === 'counter'
+			&& exposed.type === 'string'
+			&& exposed.documentationComment === 'a counter string'
+		);
+
+		expect(counter).toBeDefined();
+	})
 });

--- a/packages/vue-test-workspace/vue-component-meta/reference-type-exposed/component.vue
+++ b/packages/vue-test-workspace/vue-component-meta/reference-type-exposed/component.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const counter = ref('foo')
+
+defineExpose({
+	/**
+	 * a counter string
+	 */
+	counter
+});
+</script>


### PR DESCRIPTION
When a component uses `expose` or `defineExpose()` on its methods or data, it needs to be documented.

This PR adds documentation for the method.