### PR TITLE
[vue-component-meta] fix: recursive schema parsing

### DIFF
--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -56,7 +56,7 @@ describe(`vue-component-meta`, () => {
 		const enumValue = meta.props.find(prop => prop.name === 'enumValue');
 		const literalFromContext = meta.props.find(prop => prop.name === 'literalFromContext');
 		const inlined = meta.props.find(prop => prop.name === 'inlined');
-		// const onEvent = meta.props.find(prop => prop.name === 'onEvent');
+		const recursive = meta.props.find(prop => prop.name === 'recursive');
 
 		expect(foo).toBeDefined();
 		expect(foo?.required).toBeTruthy();
@@ -311,27 +311,24 @@ describe(`vue-component-meta`, () => {
 			]
 		});
 
-		// expect(onEvent).toBeDefined();
-		// // expect(onEvent?.required).toBeFalsy()
-		// expect(onEvent?.type).toEqual('((...args: any[]) => any) | undefined');
-		// expect(onEvent?.schema).toEqual({
-		// 	kind: 'enum',
-		// 	type: '((...args: any[]) => any) | undefined',
-		// 	schema: [
-		// 		'undefined',
-		// 		{
-		// 			kind: 'event',
-		// 			type: '(...args: any[]): any',
-		// 			schema: [
-		// 				{
-		// 					kind: 'array',
-		// 					type: 'any',
-		// 					schema: [],
-		// 				}
-		// 			]
-		// 		}
-		// 	]
-		// });
+		expect(recursive).toBeDefined();
+		expect(recursive?.required).toBeTruthy();
+		expect(recursive?.type).toEqual('MyNestedRecursiveProps');
+		expect(recursive?.schema).toEqual({
+			kind: 'object',
+			type: 'MyNestedRecursiveProps',
+			schema: {
+				recursive: {
+					name: 'recursive',
+					description: '',
+					tags: [],
+					global: false,
+					required: true,
+					type: 'MyNestedRecursiveProps',
+					schema: 'MyNestedRecursiveProps'
+				}
+			}
+		});
 	});
 
 	test('reference-type-props-js', () => {

--- a/packages/vue-test-workspace/vue-component-meta/reference-type-props/my-props.ts
+++ b/packages/vue-test-workspace/vue-component-meta/reference-type-props/my-props.ts
@@ -9,6 +9,10 @@ export interface MyIgnoredNestedProps {
 	nestedProp: string;
 }
 
+export interface MyNestedRecursiveProps {
+	recursive: MyNestedRecursiveProps
+}
+
 enum MyEnum {
 	Small,
 	Medium,
@@ -91,4 +95,5 @@ export interface MyProps {
 	 */
 	literalFromContext: MyCategories,
 	inlined: { foo: string; },
+	recursive: MyNestedRecursiveProps
 }


### PR DESCRIPTION
This fix `maximum stack size exceeded` when props use recursive types like:

```ts
export interface MyNestedRecursiveProps {
  recursive: MyNestedRecursiveProps
}
defineProps<{
  myProp: MyNestedRecursiveProps
}>()
```
