### PR TITLE
[vue-component-meta] fix: parse defineProps in script setup with option

### DIFF
--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -7,9 +7,8 @@ describe(`vue-component-meta`, () => {
 	const tsconfigPath = path.resolve(__dirname, '../../vue-test-workspace/vue-component-meta/tsconfig.json');
 	const checker = createComponentMetaChecker(tsconfigPath, {
 		forceUseTs: true,
-		schema: {
-			ignore: ['MyIgnoredNestedProps'],
-		},
+		schema: { ignore: ['MyIgnoredNestedProps'] },
+		printer: { newLine: 1 },
 	});
 
 	test('empty-component', () => {

--- a/packages/vue-test-workspace/vue-component-meta/reference-type-props/component-js-setup.vue
+++ b/packages/vue-test-workspace/vue-component-meta/reference-type-props/component-js-setup.vue
@@ -1,0 +1,28 @@
+<script setup>
+defineProps({
+  /**
+   * Required foo property
+   */
+  foo: {
+    type: String,
+		required: true,
+  },
+  /**
+   * The hello property.
+   *
+   * @since v1.0.0
+   */
+  hello: {
+    type: String,
+    default: 'Hello'
+  },
+  numberOrStringProp: {
+    type: [Number, String],
+    default: 42
+  },
+  arrayProps: {
+    type: Array,
+    default: () => [42, 43, 44]
+  }
+})
+</script>


### PR DESCRIPTION
This allows to parse `defineProps` in `<script setup>`


```vue
<script setup>
defineProps({
  /**
   * Required foo property
   */
  foo: {
    type: String,
    required: true,
  },
  /**
   * The hello property.
   *
   * @since v1.0.0
   */
  hello: {
    type: String,
    default: 'Hello'
  },
  numberOrStringProp: {
    type: [Number, String],
    default: 42
  },
  arrayProps: {
    type: Array,
    default: () => [42, 43, 44]
  }
})
</script>
```


chore:
- use same checker instance in tests (may we want to enable `schema` and `printer` by default?) 