### PR TITLE
feat: Support for Plugin API

### DIFF
--- a/packages/alpine-language-core/src/index.ts
+++ b/packages/alpine-language-core/src/index.ts
@@ -1,5 +1,5 @@
 import * as vue from '@volar/vue-language-core';
-import useHtmlFilePlugin from './plugins/file-html';
+import * as useHtmlFilePlugin from './plugins/file-html';
 
 export type LanguageServiceHost = vue.LanguageServiceHost;
 

--- a/packages/alpine-language-core/src/plugins/file-html.ts
+++ b/packages/alpine-language-core/src/plugins/file-html.ts
@@ -1,5 +1,5 @@
 import { VueLanguagePlugin } from '@volar/vue-language-core';
-import useVueHtmlFilePlugin from '@volar/vue-language-core/out/plugins/file-html';
+import * as useVueHtmlFilePlugin from '@volar/vue-language-core/out/plugins/file-html';
 
 const plugin: VueLanguagePlugin = (ctx) => {
 
@@ -33,4 +33,4 @@ const plugin: VueLanguagePlugin = (ctx) => {
 		}
 	};
 };
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/packages/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -22,6 +22,11 @@
 					"default": false,
 					"markdownDescription": "Strict props, component type-checking in templates."
 				},
+				"plugins": {
+					"type": "array",
+					"default": [],
+					"markdownDescription": "Plugins to be used in the SFC compiler."
+				},
 				"experimentalRuntimeMode": {
 					"type": "string",
 					"default": "runtime-dom",

--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -597,6 +597,7 @@ export function generate(
 		const useGlobalThisTypeInCtx = fileName.endsWith('.html');
 
 		codeGen.addText(`let __VLS_ctx!: ${useGlobalThisTypeInCtx ? 'typeof globalThis &' : ''}`);
+		codeGen.addText(`__VLS_types.PickNotAny<__VLS_Ctx, {}> & `);
 		if (sfc.scriptSetup) {
 			codeGen.addText(`InstanceType<__VLS_types.PickNotAny<typeof __VLS_Component, new () => {}>> & `);
 		}

--- a/packages/vue-language-core/src/plugins/empty.ts
+++ b/packages/vue-language-core/src/plugins/empty.ts
@@ -3,4 +3,4 @@ import { VueLanguagePlugin } from '../sourceFile';
 const plugin: VueLanguagePlugin = () => {
 	return {};
 };
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/file-html.ts
+++ b/packages/vue-language-core/src/plugins/file-html.ts
@@ -86,4 +86,4 @@ const plugin: VueLanguagePlugin = () => {
 		}
 	};
 }
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/file-md.ts
+++ b/packages/vue-language-core/src/plugins/file-md.ts
@@ -85,4 +85,4 @@ const plugin: VueLanguagePlugin = () => {
 		}
 	};
 }
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/file-vue.ts
+++ b/packages/vue-language-core/src/plugins/file-vue.ts
@@ -14,4 +14,4 @@ const plugin: VueLanguagePlugin = () => {
 		}
 	};
 }
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/vue-sfc-customblocks.ts
+++ b/packages/vue-language-core/src/plugins/vue-sfc-customblocks.ts
@@ -54,4 +54,4 @@ const plugin: VueLanguagePlugin = () => {
 		},
 	};
 }
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/vue-sfc-scripts.ts
+++ b/packages/vue-language-core/src/plugins/vue-sfc-scripts.ts
@@ -46,4 +46,4 @@ const plugin: VueLanguagePlugin = () => {
 		},
 	};
 }
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/vue-sfc-styles.ts
+++ b/packages/vue-language-core/src/plugins/vue-sfc-styles.ts
@@ -54,4 +54,4 @@ const plugin: VueLanguagePlugin = () => {
 		},
 	};
 }
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/vue-sfc-template.ts
+++ b/packages/vue-language-core/src/plugins/vue-sfc-template.ts
@@ -48,4 +48,4 @@ const plugin: VueLanguagePlugin = () => {
 		},
 	};
 }
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/vue-template-html.ts
+++ b/packages/vue-language-core/src/plugins/vue-template-html.ts
@@ -17,4 +17,4 @@ const plugin: VueLanguagePlugin = ({ vueCompilerOptions }) => {
 		},
 	};
 };
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/vue-template-pug.ts
+++ b/packages/vue-language-core/src/plugins/vue-template-pug.ts
@@ -54,4 +54,4 @@ const plugin: VueLanguagePlugin = ({ vueCompilerOptions }) => {
 		},
 	};
 };
-export default plugin;
+export = plugin;

--- a/packages/vue-language-core/src/plugins/vue-tsx.ts
+++ b/packages/vue-language-core/src/plugins/vue-tsx.ts
@@ -46,8 +46,9 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 				};
 				const tsx = _gen?.tsxGen.value;
 				if (tsx) {
-					embeddedFile.codeGen = tsx.codeGen;
-					embeddedFile.teleportMappings = tsx.teleports;
+					embeddedFile.codeGen.addText(tsx.codeGen.getText());
+					embeddedFile.codeGen.mappings = [...tsx.codeGen.mappings];
+					embeddedFile.teleportMappings = [...tsx.teleports];
 				}
 			}
 			else if (suffix.match(/^\.__VLS_template_format\.tsx$/)) {
@@ -64,7 +65,8 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 				embeddedFile.isTsHostFile = false;
 
 				if (_gen?.htmlGen.value) {
-					embeddedFile.codeGen = _gen.htmlGen.value.formatCodeGen;
+					embeddedFile.codeGen.addText(_gen.htmlGen.value.formatCodeGen.getText());
+					embeddedFile.codeGen.mappings = [..._gen.htmlGen.value.formatCodeGen.mappings];
 				}
 			}
 			else if (suffix.match(/^\.__VLS_template\.css$/)) {
@@ -72,7 +74,8 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 				embeddedFile.parentFileName = fileName + '.' + sfc.template?.lang;
 
 				if (_gen?.htmlGen.value) {
-					embeddedFile.codeGen = _gen.htmlGen.value.cssCodeGen;
+					embeddedFile.codeGen.addText(_gen.htmlGen.value.cssCodeGen.getText());
+					embeddedFile.codeGen.mappings = [..._gen.htmlGen.value.cssCodeGen.mappings];
 				}
 			}
 		},

--- a/packages/vue-language-core/src/sourceFile.ts
+++ b/packages/vue-language-core/src/sourceFile.ts
@@ -10,7 +10,7 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 
 export type VueLanguagePlugin = (ctx: {
 	modules: {
-		typescript: typeof ts,
+		typescript: typeof import('typescript/lib/tsserverlibrary');
 	},
 	compilerOptions: ts.CompilerOptions,
 	vueCompilerOptions: _VueCompilerOptions,

--- a/packages/vue-language-core/src/types.ts
+++ b/packages/vue-language-core/src/types.ts
@@ -12,6 +12,7 @@ export type VueCompilerOptions = Partial<_VueCompilerOptions>;
 export interface _VueCompilerOptions {
 	target: 2 | 2.7 | 3;
 	strictTemplates: boolean;
+	plugins: string[];
 
 	// experimental
 	experimentalRuntimeMode: 'runtime-dom' | 'runtime-uni-app';

--- a/packages/vue-language-core/src/utils/ts.ts
+++ b/packages/vue-language-core/src/utils/ts.ts
@@ -50,6 +50,7 @@ export function getVueCompilerOptions(vueOptions: VueCompilerOptions): _VueCompi
 
 		target: vueOptions.target ?? 3,
 		strictTemplates: vueOptions.strictTemplates ?? false,
+		plugins: vueOptions.plugins ?? [],
 
 		// experimental
 		experimentalRuntimeMode: vueOptions.experimentalRuntimeMode ?? 'runtime-dom',

--- a/packages/vue-language-service/src/documentService.ts
+++ b/packages/vue-language-service/src/documentService.ts
@@ -104,7 +104,7 @@ export function getDocumentService(
 			}
 		},
 	};
-	const vuePlugins = vue.getPlugins(ts, {}, {}, []);
+	const vuePlugins = vue.getPlugins(ts, '', {}, {}, []);
 
 	return {
 		format: format.register(context),


### PR DESCRIPTION
Closes #185

Please note that the API interface is not stable, it may change before v1.0.

## Usage

- `tsconfig.json`

```jsoncc
{
  "vueCompilerOptions": {
    "plugins": ["./your-plugin"]
  }
}
```

Example: https://github.com/johnsoncodehk/volar-starter/blob/master/vue-i18n.js