### PR TITLE
Add tests for props declared via definition constants

### DIFF
--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -374,7 +374,7 @@ describe(`vue-component-meta`, () => {
 		expect(xfoo).toBeDefined();
 		expect(xfoo?.default).toBeUndefined();
 		expect(xfoo?.required).toBeTruthy();
-		// expect(xfoo?.type).toEqual('string'); // @todo should be `string` (#1695)
+		expect(xfoo?.type).toEqual('string'); 
 
 		expect(xbar).toBeDefined();
 		// expect(xbar?.default).toBe('""'); // @toto should be empty string
@@ -419,7 +419,7 @@ describe(`vue-component-meta`, () => {
 
 		expect(xfoo).toBeDefined();
 		expect(xfoo?.default).toBeUndefined();
-		// expect(xfoo?.type).toEqual('string'); // @todo should be 'string' (#1695)
+		expect(xfoo?.type).toEqual('string');
 		expect(xfoo?.required).toBeTruthy();
 
 		expect(xbar).toBeDefined();

--- a/packages/vue-component-meta/tests/index.spec.ts
+++ b/packages/vue-component-meta/tests/index.spec.ts
@@ -352,6 +352,9 @@ describe(`vue-component-meta`, () => {
 		const foo = meta.props.find(prop => prop.name === 'foo');
 		const bar = meta.props.find(prop => prop.name === 'bar');
 		const baz = meta.props.find(prop => prop.name === 'baz');
+		const xfoo = meta.props.find(prop => prop.name === 'xfoo');
+		const xbar = meta.props.find(prop => prop.name === 'xbar');
+		const xbaz = meta.props.find(prop => prop.name === 'xbaz');
 
 		expect(foo).toBeDefined();
 		expect(foo?.default).toBeUndefined();
@@ -367,6 +370,21 @@ describe(`vue-component-meta`, () => {
 		expect(baz?.default).toBeUndefined();
 		// expect(baz?.required).toBeFalsy(); // @todo should not be required
 		expect(baz?.type).toEqual('string | undefined');
+
+		expect(xfoo).toBeDefined();
+		expect(xfoo?.default).toBeUndefined();
+		expect(xfoo?.required).toBeTruthy();
+		// expect(xfoo?.type).toEqual('string'); // @todo should be `string` (#1695)
+
+		expect(xbar).toBeDefined();
+		// expect(xbar?.default).toBe('""'); // @toto should be empty string
+		// expect(xbar?.required).toBeFalsy(); // @todo should not be required
+		expect(xbar?.type).toEqual('string | undefined');
+
+		expect(xbaz).toBeDefined();
+		expect(xbaz?.default).toBeUndefined();
+		// expect(baz?.required).toBeFalsy(); // @todo should not be required
+		expect(xbaz?.type).toEqual('string | undefined');
 	});
 
 	test('reference-type-props-js-setup', () => {
@@ -376,6 +394,9 @@ describe(`vue-component-meta`, () => {
 		const foo = meta.props.find(prop => prop.name === 'foo');
 		const bar = meta.props.find(prop => prop.name === 'bar');
 		const baz = meta.props.find(prop => prop.name === 'baz');
+		const xfoo = meta.props.find(prop => prop.name === 'xfoo');
+		const xbar = meta.props.find(prop => prop.name === 'xbar');
+		const xbaz = meta.props.find(prop => prop.name === 'xbaz');
 
 		const hello = meta.props.find(prop => prop.name === 'hello');
 		const numberOrStringProp = meta.props.find(prop => prop.name === 'numberOrStringProp');
@@ -394,6 +415,21 @@ describe(`vue-component-meta`, () => {
 		expect(baz).toBeDefined();
 		expect(baz?.default).toBeUndefined();
 		expect(baz?.type).toEqual('string | undefined');
+		// expect(baz?.required).toBeFalsy(); // @todo should not be required
+
+		expect(xfoo).toBeDefined();
+		expect(xfoo?.default).toBeUndefined();
+		// expect(xfoo?.type).toEqual('string'); // @todo should be 'string' (#1695)
+		expect(xfoo?.required).toBeTruthy();
+
+		expect(xbar).toBeDefined();
+		// expect(xbar?.default).toBe('""'); // @todo should be empty string
+		expect(xbar?.type).toEqual('string | undefined');
+		// expect(xbar?.required).toBeFalsy(); // @todo should not be required
+
+		expect(xbaz).toBeDefined();
+		expect(xbaz?.default).toBeUndefined();
+		expect(xbaz?.type).toEqual('string | undefined');
 		// expect(baz?.required).toBeFalsy(); // @todo should not be required
 
 		expect(hello).toBeDefined();

--- a/packages/vue-test-workspace/vue-component-meta/reference-type-props/component-js-setup.vue
+++ b/packages/vue-test-workspace/vue-component-meta/reference-type-props/component-js-setup.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { StringEmpty, StringRequired, StringUndefined } from './my-props';
 
 defineProps({
   foo: {
@@ -12,6 +13,9 @@ defineProps({
   baz: {
     type: String
   },
+  xfoo: StringRequired,
+  xbar: StringEmpty,
+  xbaz: StringUndefined,
   /**
    * The hello property.
    *

--- a/packages/vue-test-workspace/vue-component-meta/reference-type-props/component-js.vue
+++ b/packages/vue-test-workspace/vue-component-meta/reference-type-props/component-js.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { StringEmpty, StringRequired, StringUndefined } from './my-props';
 
 export default defineComponent({
   props: {
@@ -13,7 +14,10 @@ export default defineComponent({
 	},
     baz: {
 		type: String
-	}
+	},
+	xfoo: StringRequired,
+	xbar: StringEmpty,
+	xbaz: StringUndefined,
   }
 })
 </script>

--- a/packages/vue-test-workspace/vue-component-meta/reference-type-props/my-props.ts
+++ b/packages/vue-test-workspace/vue-component-meta/reference-type-props/my-props.ts
@@ -101,13 +101,13 @@ export interface MyProps {
 export const StringRequired = {
 	type: String,
 	required: true,
-}
+} as const
 
 export const StringEmpty = {
 	type: String,
 	value: '',
-}
+} as const
 
 export const StringUndefined = {
 	type: String,
-}
+} as const

--- a/packages/vue-test-workspace/vue-component-meta/reference-type-props/my-props.ts
+++ b/packages/vue-test-workspace/vue-component-meta/reference-type-props/my-props.ts
@@ -97,3 +97,17 @@ export interface MyProps {
 	inlined: { foo: string; },
 	recursive: MyNestedRecursiveProps
 }
+
+export const StringRequired = {
+	type: String,
+	required: true,
+}
+
+export const StringEmpty = {
+	type: String,
+	value: '',
+}
+
+export const StringUndefined = {
+	type: String,
+}


### PR DESCRIPTION
Extra tests to verify the behavior noticed in issue [(#1695) ](https://github.com/johnsoncodehk/volar/issues/1695) and other related aspects.

We could resolve identifiers when used in property initializers, like we do for object literal expressions. I'm interested to discuss a reasonable approach and maybe do the actual work. 