### PR TITLE
docs: add guide of global components for vue 2

### DIFF
--- a/extensions/vscode-vue-language-features/README.md
+++ b/extensions/vscode-vue-language-features/README.md
@@ -90,7 +90,9 @@ For Global components, you need to define `GlobalComponents` interface, for exam
 
 ```typescript
 // components.d.ts
-declare module '@vue/runtime-core' {
+declare module '@vue/runtime-core' {  // Vue 3
+// declare module 'vue' {   // Vue 2.7
+// declare module '@vue/runtime-dom' {  // Vue <= 2.6.14
   export interface GlobalComponents {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']


### PR DESCRIPTION
fix #1658