### PR TITLE
Set style property to "" instead of to undefined

### DIFF
--- a/packages/vue-language-core/src/generators/template.ts
+++ b/packages/vue-language-core/src/generators/template.ts
@@ -980,7 +980,7 @@ export function generate(
 					}
 				}
 				else {
-					tsCodeGen.addText('undefined');
+					tsCodeGen.addText('""');
 				}
 				writePropValueSuffix(isStatic);
 				tsCodeGen.addMapping2({


### PR DESCRIPTION
Fixes johnsoncodehk/volar#1560

In some cases the template generator sets the `style` property to `undefined` , which is not accepted by TypeScript when `exactOptionalPropertyTypes: true` in `tsconfig.json`.

This PR changes the template generator to emit empty string (`""`) instead of `undefined`  for `style` in those cases.
