### PR TITLE
Update vite problemMatcher endsPattern with "server restarted."

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -807,7 +807,7 @@
 				"background": {
 					"activeOnStart": true,
 					"beginsPattern": "restarting server...$",
-					"endsPattern": "\\s*ready in"
+					"endsPattern": "\\s*ready in|server restarted."
 				}
 			}
 		]


### PR DESCRIPTION
This makes it correctly detect that Vite is ready again after a Vite restart from config changes.