### PR TITLE
Check `workspaceFolders` capability before registering `onDidChangeWorkspaceFolders` handler

### DIFF
--- a/packages/vue-language-server/src/commonServer.ts
+++ b/packages/vue-language-server/src/commonServer.ts
@@ -112,18 +112,20 @@ export function createLanguageServer(
 		fsHost?.ready(connection);
 		configHost?.ready();
 
-		connection.workspace.onDidChangeWorkspaceFolders(e => {
+		if (params.capabilities.workspace?.workspaceFolders) {
+			connection.workspace.onDidChangeWorkspaceFolders(e => {
 
-			for (const folder of e.added) {
-				documentServiceHost?.add(URI.parse(folder.uri));
-				projects?.add(URI.parse(folder.uri));
-			}
+				for (const folder of e.added) {
+					documentServiceHost?.add(URI.parse(folder.uri));
+					projects?.add(URI.parse(folder.uri));
+				}
 
-			for (const folder of e.removed) {
-				documentServiceHost?.remove(URI.parse(folder.uri));
-				projects?.remove(URI.parse(folder.uri));
-			}
-		});
+				for (const folder of e.removed) {
+					documentServiceHost?.remove(URI.parse(folder.uri));
+					projects?.remove(URI.parse(folder.uri));
+				}
+			});
+		}
 	});
 	connection.listen();
 }


### PR DESCRIPTION
When volar is used with LSP clients which doesn't support `workspaceFolders`, the exception from the following part is raised.

https://github.com/microsoft/vscode-languageserver-node/blob/5c2e1065493290110bd7c7ea1b10cd6fa08eb81c/server/src/common/workspaceFolder.ts#L48-L50

So, I add code to check `workspaceFolders` capability also before registering `onDidChangeWorkspaceFolders` handler.