### PR TITLE
Enable class/object literal method completions

### DIFF
--- a/packages/typescript-language-service/src/configs/getUserPreferences.ts
+++ b/packages/typescript-language-service/src/configs/getUserPreferences.ts
@@ -25,6 +25,8 @@ export async function getUserPreferences(
 		// @ts-ignore
 		includeCompletionsForImportStatements: config.suggest?.includeCompletionsForImportStatements ?? true,
 		includeCompletionsWithSnippetText: config.suggest?.includeCompletionsWithSnippetText ?? true,
+		includeCompletionsWithClassMemberSnippets: config.suggest?.classMemberSnippets.enabled ?? true,
+		includeCompletionsWithObjectLiteralMethodSnippets: config.suggest?.objectLiteralMethodSnippets.enabled ?? true,
 		allowIncompleteCompletions: true,
 		// @ts-ignore
 		displayPartsForJSDoc: true,


### PR DESCRIPTION
[vscode reference](https://github.com/microsoft/vscode/blob/077f5865dac519a9ce6145b39065cee0b5952232/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts#L192)

An example script, where you can take advantage. Unfortunately I didn't figure out a way to enable object literal method completions in `js` lang (but in theory it works fine in both).

```vue
<script lang="ts">
    import Vue, { defineComponent, Component } from 'vue'
    defineComponent({
        activated // trigger
        activated() {
        
        }
    })
    interface Test {
        callback()
    }
    class TestImpl implements Test {
        callback // trigger
        callback() {
        
        }
    }
</script>
```

While the first case is useful specifically in vue sfc, second case is still useful when using takeover mode.

I checked this only in VSCode.