### PR TITLE
feat: svelte language server example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,6 +41,25 @@
 			}
 		},
 		{
+			"name": "Launch Svelte Example",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceRoot}/examples/svelte"
+			],
+			"outFiles": [
+				"${workspaceRoot}/examples/*/out/**/*.js",
+				"${workspaceRoot}/packages/*/out/**/*.js",
+				"${workspaceRoot}/plugins/*/out/**/*.js"
+			],
+			"preLaunchTask": {
+				"type": "npm",
+				"script": "watch"
+			}
+		},
+		{
 			"type": "extensionHost",
 			"request": "launch",
 			"name": "Launch TypeScript Vue Plugin",
@@ -86,6 +105,7 @@
 			"port": 6009,
 			"restart": true,
 			"outFiles": [
+				"${workspaceRoot}/examples/*/out/**/*.js",
 				"${workspaceRoot}/packages/*/out/**/*.js",
 				"${workspaceRoot}/plugins/*/out/**/*.js"
 			]
@@ -97,6 +117,7 @@
 			"port": 6010,
 			"restart": true,
 			"outFiles": [
+				"${workspaceRoot}/examples/*/out/**/*.js",
 				"${workspaceRoot}/packages/*/out/**/*.js",
 				"${workspaceRoot}/plugins/*/out/**/*.js"
 			]
@@ -108,6 +129,7 @@
 			"port": 6011,
 			"restart": true,
 			"outFiles": [
+				"${workspaceRoot}/examples/*/out/**/*.js",
 				"${workspaceRoot}/packages/*/out/**/*.js",
 				"${workspaceRoot}/plugins/*/out/**/*.js"
 			]

--- a/examples/svelte/.vscodeignore
+++ b/examples/svelte/.vscodeignore
@@ -1,0 +1,3 @@
+src
+tsconfig.build.json
+tsconfig.build.tsbuildinfo

--- a/examples/svelte/LICENSE
+++ b/examples/svelte/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -1,3 +1,17 @@
 # Svelte Langauge Server Example
 
-TODO
+This example show how to create a Svelte langauge server via Volar framework.
+
+With this solution you can avoid dealing with problems that usually require a lot of effort to solve, such as:
+
+- Multi-level nested embedded language
+- Embedded code mapping
+- TypeScript langauge service performance optimization
+- Web IDE support
+- Incremental parser
+
+Even downstream IDE clients (`coc-volar`, `sublimelsp/LSP-volar`...) can simply support the language server created by this.
+
+To run this example, you can run `Launch Svelte Example` on debug, and open a Svelte project in the newly opened VSCode window.
+
+Please note that this example is not support `vsce package` for `vsce publish` out of box, because this repo using pnpm and vsce do not support it. To resolve it, you should change pnpm to yarn / npm, or [bundling the extension](https://code.visualstudio.com/api/working-with-extensions/bundling-extension).

--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -1,0 +1,3 @@
+# Svelte Langauge Server Example
+
+TODO

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -1,0 +1,81 @@
+{
+	"private": true,
+	"name": "svelte-language-server-example",
+	"version": "0.40.13",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/johnsoncodehk/volar.git",
+		"directory": "examples/svelte"
+	},
+	"displayName": "Svelte Langauge Server (Example)",
+	"description": "Svelte Langauge Server Example",
+	"author": "johnsoncodehk",
+	"publisher": "johnsoncodehk",
+	"engines": {
+		"vscode": "^1.67.0"
+	},
+	"keywords": [
+		"svelte"
+	],
+	"activationEvents": [
+		"onLanguage:svelte"
+	],
+	"main": "out/client",
+	"contributes": {
+		"languages": [
+			{
+				"id": "svelte",
+				"extensions": [
+					".svelte"
+				]
+			}
+		],
+		"semanticTokenScopes": [
+			{
+				"language": "svelte",
+				"scopes": {
+					"property": [
+						"variable.other.property.svelte"
+					],
+					"property.readonly": [
+						"variable.other.constant.property.svelte"
+					],
+					"variable": [
+						"variable.other.readwrite.svelte"
+					],
+					"variable.readonly": [
+						"variable.other.constant.object.svelte"
+					],
+					"function": [
+						"entity.name.function.svelte"
+					],
+					"namespace": [
+						"entity.name.type.module.svelte"
+					],
+					"variable.defaultLibrary": [
+						"support.variable.svelte"
+					],
+					"function.defaultLibrary": [
+						"support.function.svelte"
+					],
+					"componentTag": [
+						"support.class.component.svelte"
+					]
+				}
+			}
+		]
+	},
+	"scripts": {
+		"release": "vsce publish"
+	},
+	"devDependencies": {
+		"@types/vscode": "1.67.0",
+		"vsce": "latest"
+	},
+	"dependencies": {
+		"@volar-plugins/css": "0.40.13",
+		"@volar-plugins/typescript": "0.40.13",
+		"@volar/language-server": "0.40.13",
+		"vscode-languageclient": "^8.0.2"
+	}
+}

--- a/examples/svelte/src/client.ts
+++ b/examples/svelte/src/client.ts
@@ -1,0 +1,92 @@
+import { ServerInitializationOptions } from '@volar/language-server';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as lsp from 'vscode-languageclient/node';
+
+let client: lsp.BaseLanguageClient;
+
+export async function activate(context: vscode.ExtensionContext) {
+
+	vscode.commands.executeCommand('setContext', 'volar.activated', true);
+
+	const documentSelector: lsp.DocumentSelector = [{ language: 'svelte' }];
+	const initializationOptions: ServerInitializationOptions = {
+		typescript: {
+			serverPath: path.join(vscode.env.appRoot, 'extensions', 'node_modules', 'typescript', 'lib', 'typescript.js'),
+		},
+		languageFeatures: {
+			references: true,
+			implementation: true,
+			definition: true,
+			typeDefinition: true,
+			callHierarchy: true,
+			hover: true,
+			rename: true,
+			renameFileRefactoring: true,
+			signatureHelp: true,
+			codeAction: true,
+			workspaceSymbol: true,
+			completion: true,
+			documentHighlight: true,
+			documentLink: true,
+			codeLens: true,
+			semanticTokens: true,
+			inlayHints: true,
+			diagnostics: true,
+		},
+		documentFeatures: {
+			selectionRange: true,
+			foldingRange: true,
+			linkedEditingRange: true,
+			documentSymbol: true,
+			documentColor: true,
+			documentFormatting: true,
+		},
+	};
+	const serverModule = vscode.Uri.joinPath(context.extensionUri, 'out', 'server');
+	const runOptions = { execArgv: <string[]>[] };
+	const debugOptions = { execArgv: ['--nolazy', '--inspect=' + 6009] };
+	const serverOptions: lsp.ServerOptions = {
+		run: {
+			module: serverModule.fsPath,
+			transport: lsp.TransportKind.ipc,
+			options: runOptions
+		},
+		debug: {
+			module: serverModule.fsPath,
+			transport: lsp.TransportKind.ipc,
+			options: debugOptions
+		},
+	};
+	const clientOptions: lsp.LanguageClientOptions = {
+		documentSelector,
+		initializationOptions,
+		synchronize: {
+			fileEvents: vscode.workspace.createFileSystemWatcher('{**/*.svelte,**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.json}')
+		},
+		middleware: {
+			workspace: {
+				configuration(params, token, next) {
+					if (params.items.length === 1 && params.items[0].section === 'volar.format.initialIndent') {
+						return [{
+							javascript: true,
+							css: true,
+						}];
+					}
+					return next(params, token);
+				}
+			}
+		}
+	};
+	client = new lsp.LanguageClient(
+		'svelte-language-server',
+		'Svelte Langauge Server',
+		serverOptions,
+		clientOptions,
+	);
+	await client.start();
+}
+
+export function deactivate(): Thenable<any> | undefined {
+	return client?.stop();
+}

--- a/examples/svelte/src/client.ts
+++ b/examples/svelte/src/client.ts
@@ -7,8 +7,6 @@ let client: lsp.BaseLanguageClient;
 
 export async function activate(context: vscode.ExtensionContext) {
 
-	vscode.commands.executeCommand('setContext', 'volar.activated', true);
-
 	const documentSelector: lsp.DocumentSelector = [{ language: 'svelte' }];
 	const initializationOptions: ServerInitializationOptions = {
 		typescript: {

--- a/examples/svelte/src/server.ts
+++ b/examples/svelte/src/server.ts
@@ -1,0 +1,140 @@
+import useCssPlugin from '@volar-plugins/css';
+import useTsPlugin, { getSemanticTokenLegend } from '@volar-plugins/typescript';
+import { createNodeServer, EmbeddedLanguageModule, FileNode } from '@volar/language-server/node';
+
+const blocksReg = /\<(script|style)[\s\S]*?\>([\s\S]*?)\<\/\1\>/g;
+
+const mod: EmbeddedLanguageModule<FileNode & { snapshot: any; }> = {
+	createSourceFile(fileName, snapshot) {
+		if (fileName.endsWith('.svelte')) {
+
+			const text = snapshot.getText(0, snapshot.getLength());
+
+			return {
+				snapshot,
+				fileName,
+				text,
+				isTsHostFile: false,
+				capabilities: {},
+				mappings: [],
+				embeddeds: getEmbeddeds(fileName, text),
+			};
+		}
+	},
+	updateSourceFile(sourceFile, snapshot) {
+
+		const change = snapshot.getChangeRange(sourceFile.snapshot);
+
+		sourceFile.text = snapshot.getText(0, snapshot.getLength());
+		sourceFile.snapshot = snapshot;
+
+		let incrementalUpdateFailed = false;
+
+		if (change) {
+
+			const changeStart = change.span.start;
+			const changeEnd = change.span.start + change.span.length;
+			const newText = snapshot.getText(changeStart, changeStart + change.newLength);
+			const lengthDiff = change.newLength - (changeEnd - changeStart);
+
+			for (const embedded of sourceFile.embeddeds) {
+
+				const blockStart = embedded.mappings[0].sourceRange.start;
+				const blockEnd = embedded.mappings[0].sourceRange.end;
+
+				if (changeStart >= blockStart && changeEnd <= blockEnd) {
+					const a = snapshot.getText(blockStart, changeStart);
+					const b = newText;
+					const c = snapshot.getText(changeEnd + lengthDiff, blockEnd + lengthDiff);
+					embedded.text = a + b + c;
+					embedded.mappings[0].mappedRange.end += lengthDiff;
+					embedded.mappings[0].sourceRange.end += lengthDiff;
+				}
+				else if (changeEnd <= blockStart && changeStart < blockStart) {
+					embedded.mappings[0].sourceRange.start += lengthDiff;
+					embedded.mappings[0].sourceRange.end += lengthDiff;
+				}
+				else if (changeStart >= blockEnd && changeEnd > blockEnd) {
+					// No need update
+				}
+				else {
+					incrementalUpdateFailed = true;
+				}
+			}
+		}
+		else {
+			incrementalUpdateFailed = true;
+		}
+
+		if (incrementalUpdateFailed) {
+			// full update
+			sourceFile.embeddeds = getEmbeddeds(sourceFile.fileName, sourceFile.text);
+		}
+	},
+};
+
+function getEmbeddeds(fileName: string, text: string) {
+	return [...text.matchAll(blocksReg)].map(block => {
+		const content = block[2];
+		const start = block.index! + block[0].indexOf(content);
+		const end = start + content.length;;
+		return {
+			fileName: fileName + (block[1] === 'script' ? '.js' : '.css'),
+			text: block[2],
+			isTsHostFile: block[1] === 'script',
+			capabilities: {
+				diagnostics: true,
+				foldingRanges: true,
+				documentSymbol: true,
+				codeActions: true,
+				inlayHints: true,
+				formatting: { initialIndentBracket: ['{', '}'] as [string, string] },
+				// formatting: true,
+			},
+			mappings: [
+				{
+					sourceRange: { start, end },
+					mappedRange: { start: 0, end: content.length },
+					mode: 1,
+					data: {
+						hover: true,
+						references: true,
+						definitions: true,
+						rename: true,
+						completion: true,
+						diagnostic: true,
+						semanticTokens: true,
+					},
+				}
+			],
+			embeddeds: [],
+		};
+	});
+}
+
+createNodeServer([{
+	exts: ['.svelte'],
+	languageService: {
+		semanticTokenLegend: getSemanticTokenLegend(),
+		getLanguageModules(host) {
+			return [mod];
+		},
+		getLanguageServicePlugins() {
+			return [
+				useCssPlugin(),
+				useTsPlugin(),
+			];
+		},
+	},
+	documentService: {
+		getLanguageModules(host) {
+			return [mod];
+		},
+		getLanguageServicePlugins() {
+			return [
+				useCssPlugin(),
+				useTsPlugin(),
+			];
+		}
+	},
+}]);

--- a/examples/svelte/tsconfig.build.json
+++ b/examples/svelte/tsconfig.build.json
@@ -1,0 +1,26 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "out",
+		"rootDir": "src",
+	},
+	"include": [
+		"src",
+		"src/**/*.json"
+	],
+	"exclude": [
+		"node_modules",
+		".vscode-test"
+	],
+	"references": [
+		{
+			"path": "../../plugins/css/tsconfig.build.json"
+		},
+		{
+			"path": "../../plugins/typescript/tsconfig.build.json"
+		},
+		{
+			"path": "../../packages/language-server/tsconfig.build.json"
+		}
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,23 @@ importers:
       vitest: 0.23.2
       vue: 3.2.38
 
+  examples/svelte:
+    specifiers:
+      '@types/vscode': 1.67.0
+      '@volar-plugins/css': 0.40.13
+      '@volar-plugins/typescript': 0.40.13
+      '@volar/language-server': 0.40.13
+      vsce: latest
+      vscode-languageclient: ^8.0.2
+    dependencies:
+      '@volar-plugins/css': link:../../plugins/css
+      '@volar-plugins/typescript': link:../../plugins/typescript
+      '@volar/language-server': link:../../packages/language-server
+      vscode-languageclient: 8.0.2
+    devDependencies:
+      '@types/vscode': 1.67.0
+      vsce: 2.11.0
+
   extensions/vscode-typescript-vue-plugin:
     specifiers:
       esbuild: latest
@@ -1492,7 +1509,6 @@ packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1537,7 +1553,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: true
 
   /brace-expansion/2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -1832,7 +1847,6 @@ packages:
 
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-    dev: true
 
   /concat-stream/2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -3685,7 +3699,6 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
 
   /minimatch/5.1.0:
     resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==}
@@ -5520,7 +5533,6 @@ packages:
       minimatch: 3.1.2
       semver: 7.3.7
       vscode-languageserver-protocol: 3.17.2
-    dev: true
 
   /vscode-languageserver-protocol/3.17.2:
     resolution: {integrity: sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - 'examples/*'
   - 'extensions/*'
   - 'packages/*'
   - 'plugins/*'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,9 +2,14 @@
 	"files": [],
 	"include": [],
 	"references": [
+		// Extensions
 		{
 			"path": "./extensions/vscode-vue-language-features/tsconfig.build.json"
 		},
+		{
+			"path": "./examples/svelte/tsconfig.build.json"
+		},
+		// Extra Pkgs
 		{
 			"path": "./packages/typescript-vue-plugin/tsconfig.build.json"
 		},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"noEmit": true,
 	},
 	"include": [
+		"examples/*/src",
 		"extensions/*/src",
 		"packages/*/src",
 		"plugins/*/src",


### PR DESCRIPTION
This PR show how to create a Svelte language server via Volar framework. Please note that API will change at any time before v1.0, this is just for preview for now.

To try it, you can run "Launch Svelte Example".