### PR TITLE
feat: Config petite-vue, VitePress supports in settings

### DIFF
--- a/examples/svelte/src/server.ts
+++ b/examples/svelte/src/server.ts
@@ -1,5 +1,6 @@
 import useCssPlugin from '@volar-plugins/css';
 import useTsPlugin, { getSemanticTokenLegend } from '@volar-plugins/typescript';
+import { LanguageServerPlugin } from '@volar/language-server';
 import { createLanguageServer, EmbeddedLanguageModule, SourceFile } from '@volar/language-server/node';
 
 const blocksReg = /\<(script|style)[\s\S]*?\>([\s\S]*?)\<\/\1\>/g;
@@ -109,7 +110,7 @@ function getEmbeddeds(fileName: string, text: string) {
 	});
 }
 
-createLanguageServer([{
+const plugin: LanguageServerPlugin = () => ({
 	extensions: ['.svelte'],
 	languageService: {
 		semanticTokenLegend: getSemanticTokenLegend(),
@@ -134,4 +135,6 @@ createLanguageServer([{
 			];
 		}
 	},
-}]);
+});
+
+createLanguageServer([plugin]);

--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -50,11 +50,6 @@
 		}
 	},
 	"contributes": {
-		"configurationDefaults": {
-			"[markdown]": {
-				"editor.quickSuggestions": true
-			}
-		},
 		"views": {
 			"explorer": [
 				{
@@ -306,6 +301,14 @@
 					],
 					"default": "off",
 					"description": "Traces the communication between VS Code and the language server."
+				},
+				"volar.vueserver.petiteVue.processHtmlFile": {
+					"type": "boolean",
+					"default": false
+				},
+				"volar.vueserver.vitePress.processMdFile": {
+					"type": "boolean",
+					"default": false
 				},
 				"volar.vueserver.textDocumentSync": {
 					"type": "string",

--- a/packages/language-server/src/features/customFeatures.ts
+++ b/packages/language-server/src/features/customFeatures.ts
@@ -8,7 +8,7 @@ import { LanguageServerPlugin } from '../types';
 export function register(
 	connection: vscode.Connection,
 	projects: Workspaces,
-	plugins: LanguageServerPlugin[],
+	plugins: ReturnType<LanguageServerPlugin>[],
 ) {
 	connection.onRequest(GetMatchTsConfigRequest.type, async params => {
 		return (await projects.getProject(params.uri))?.tsconfig;

--- a/packages/language-server/src/registers/registerlanguageFeatures.ts
+++ b/packages/language-server/src/registers/registerlanguageFeatures.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode-languageserver';
 export function register(
 	features: NonNullable<ServerInitializationOptions['languageFeatures']>,
 	server: vscode.ServerCapabilities,
-	plugins: LanguageServerPlugin[],
+	plugins: ReturnType<LanguageServerPlugin>[],
 ) {
 	if (features.references) {
 		server.referencesProvider = true;

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -9,7 +9,7 @@ import { createWorkspaces } from './utils/workspaces';
 export function createCommonLanguageServer(
 	connection: vscode.Connection,
 	runtimeEnv: RuntimeEnvironment,
-	plugins: LanguageServerPlugin[],
+	_plugins: LanguageServerPlugin[],
 ) {
 
 	let params: vscode.InitializeParams;
@@ -19,6 +19,7 @@ export function createCommonLanguageServer(
 	let projects: ReturnType<typeof createWorkspaces> | undefined;
 	let documentServiceHost: ReturnType<typeof createDocumentServiceHost> | undefined;
 	let configHost: ReturnType<typeof createConfigurationHost> | undefined;
+	let plugins: ReturnType<LanguageServerPlugin>[];
 
 	const documents = createSnapshots(connection);
 
@@ -26,6 +27,7 @@ export function createCommonLanguageServer(
 
 		params = _params;
 		options = params.initializationOptions as any;
+		plugins = _plugins.map(plugin => plugin(options));
 
 		if (params.capabilities.workspace?.workspaceFolders && params.workspaceFolders) {
 			roots = params.workspaceFolders.map(folder => URI.parse(folder.uri));

--- a/packages/language-server/src/types.ts
+++ b/packages/language-server/src/types.ts
@@ -38,7 +38,11 @@ export interface RuntimeEnvironment {
 	) => FileSystemHost,
 }
 
-export type LanguageServerPlugin<A extends embedded.LanguageServiceHost = embedded.LanguageServiceHost, B = embeddedLS.LanguageService> = {
+export type LanguageServerPlugin<
+	A extends ServerInitializationOptions = ServerInitializationOptions,
+	B extends embedded.LanguageServiceHost = embedded.LanguageServiceHost,
+	C = embeddedLS.LanguageService
+> = (initOptions: A) => {
 
 	extensions: string[],
 
@@ -51,18 +55,18 @@ export type LanguageServerPlugin<A extends embedded.LanguageServiceHost = embedd
 			sys: FileSystem,
 			tsConfig: string | ts.CompilerOptions,
 			host: embedded.LanguageServiceHost,
-		): A,
+		): B,
 
-		getLanguageModules?(host: A): embedded.EmbeddedLanguageModule[],
+		getLanguageModules?(host: B): embedded.EmbeddedLanguageModule[],
 
 		getServicePlugins?(
-			host: A,
+			host: B,
 			service: embeddedLS.LanguageService,
 		): embeddedLS.EmbeddedLanguageServicePlugin[],
 
 		onInitialize?(
 			connection: vscode.Connection,
-			getLangaugeService: (uri: string) => Promise<B>,
+			getLangaugeService: (uri: string) => Promise<C>,
 		): void,
 	},
 

--- a/packages/language-server/src/utils/documentServiceHost.ts
+++ b/packages/language-server/src/utils/documentServiceHost.ts
@@ -9,7 +9,7 @@ import type * as _ from 'vscode-languageserver-textdocument';
 
 export function createDocumentServiceHost(
 	runtimeEnv: RuntimeEnvironment,
-	plugins: LanguageServerPlugin[],
+	plugins: ReturnType<LanguageServerPlugin>[],
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	configHost: ConfigurationHost | undefined,
 ) {

--- a/packages/language-server/src/utils/project.ts
+++ b/packages/language-server/src/utils/project.ts
@@ -17,7 +17,7 @@ export interface Project extends ReturnType<typeof createProject> { }
 
 export async function createProject(
 	runtimeEnv: RuntimeEnvironment,
-	plugins: LanguageServerPlugin[],
+	plugins: ReturnType<LanguageServerPlugin>[],
 	fsHost: FileSystemHost,
 	sys: FileSystem,
 	ts: typeof import('typescript/lib/tsserverlibrary'),
@@ -238,7 +238,7 @@ function createParsedCommandLine(
 	sys: FileSystem,
 	rootPath: string,
 	tsConfig: string | ts.CompilerOptions,
-	plugins: LanguageServerPlugin[],
+	plugins: ReturnType<LanguageServerPlugin>[],
 ): ts.ParsedCommandLine {
 	const extraExts = plugins.map(plugin => plugin.extensions).flat();
 	try {

--- a/packages/language-server/src/utils/workspaceProjects.ts
+++ b/packages/language-server/src/utils/workspaceProjects.ts
@@ -13,7 +13,7 @@ export const rootTsConfigNames = ['tsconfig.json', 'jsconfig.json'];
 
 export async function createWorkspaceProjects(
 	runtimeEnv: RuntimeEnvironment,
-	plugins: LanguageServerPlugin[],
+	plugins: ReturnType<LanguageServerPlugin>[],
 	fsHost: FileSystemHost,
 	rootUri: URI,
 	ts: typeof import('typescript/lib/tsserverlibrary'),

--- a/packages/language-server/src/utils/workspaces.ts
+++ b/packages/language-server/src/utils/workspaces.ts
@@ -11,7 +11,7 @@ export interface Workspaces extends ReturnType<typeof createWorkspaces> { }
 
 export function createWorkspaces(
 	runtimeEnv: RuntimeEnvironment,
-	plugins: LanguageServerPlugin[],
+	plugins: ReturnType<LanguageServerPlugin>[],
 	fsHost: FileSystemHost,
 	configurationHost: ConfigurationHost | undefined,
 	ts: typeof import('typescript/lib/tsserverlibrary'),

--- a/packages/vue-component-meta/src/index.ts
+++ b/packages/vue-component-meta/src/index.ts
@@ -102,6 +102,7 @@ function createComponentMetaCheckerBase(tsconfigPath: string, parsedCommandLine:
 		host.getCurrentDirectory(),
 		host.getCompilationSettings(),
 		host.getVueCompilationSettings(),
+		['.vue']
 	);
 	const core = embedded.createEmbeddedLanguageServiceHost(host, [vueLanguageModule]);
 	const proxyApis: Partial<ts.LanguageServiceHost> = checkerOptions.forceUseTs ? {

--- a/packages/vue-language-core/src/languageModule.ts
+++ b/packages/vue-language-core/src/languageModule.ts
@@ -11,8 +11,8 @@ export function createEmbeddedLanguageModule(
 	rootDir: string,
 	compilerOptions: ts.CompilerOptions,
 	_vueCompilerOptions: VueCompilerOptions,
+	exts: string[],
 	extraPlugins: VueLanguagePlugin[] = [],
-	exts: string[] = ['.vue', '.html', '.md'],
 ): embedded.EmbeddedLanguageModule {
 
 	const vueLanguagePlugin = getDefaultVueLanguagePlugins(

--- a/packages/vue-language-core/src/plugins/file-html.ts
+++ b/packages/vue-language-core/src/plugins/file-html.ts
@@ -1,6 +1,4 @@
-import { CodeGen } from '@volar/code-gen';
-import { SourceMapBase } from '@volar/source-map';
-import { parse, SFCBlock } from '@vue/compiler-sfc';
+import type { SFCParseResult } from '@vue/compiler-sfc';
 import { VueLanguagePlugin } from '../types';
 
 const plugin: VueLanguagePlugin = () => {
@@ -11,79 +9,83 @@ const plugin: VueLanguagePlugin = () => {
 
 			if (fileName.endsWith('.html')) {
 
-				let newContent = content;
-				let isTs = false;
+				let sfc: SFCParseResult = {
+					descriptor: {
+						filename: fileName,
+						source: content,
+						template: null,
+						script: null,
+						scriptSetup: null,
+						styles: [],
+						customBlocks: [],
+						cssVars: [],
+						shouldForceReload: () => false,
+						slotted: false,
+					},
+					errors: [],
+				};
 
-				const sfcBlockReg = /\<(script|style)[\s\S]*?\>([\s\S]*?)\<\/\1\>/g;
-				const codeGen = new CodeGen();
+				let templateContent = content;
+
+				const sfcBlockReg = /\<(script|style)([\s\S]*?)\>([\s\S]*?)\<\/\1\>/g;
+				const langReg = /\blang\s*=\s*(['\"]?)(\S*)\b\1/;
 
 				for (const match of content.matchAll(sfcBlockReg)) {
-					if (match.index !== undefined) {
-						const matchText = match[0];
-						// ignore `<script src="...">`
-						if (matchText.startsWith('<script') && matchText.indexOf('src=') >= 0) {
-							newContent = newContent.substring(0, match.index) + ' '.repeat(matchText.length) + newContent.substring(match.index + matchText.length);
-						}
-						else if (matchText.startsWith('<style')) {
-							codeGen.addCode2(matchText, match.index, undefined);
-							codeGen.addText('\n\n');
-							newContent = newContent.substring(0, match.index) + ' '.repeat(matchText.length) + newContent.substring(match.index + matchText.length);
-						}
 
-						if (matchText.startsWith('<script') && (
-							matchText.indexOf('lang="ts"') >= 0 ||
-							matchText.indexOf('lang="tsx"') >= 0
-						)) {
-							isTs = true;
-						}
+					const matchText = match[0];
+					const tag = match[1];
+					const attrs = match[2];
+					const lang = attrs.match(langReg)?.[2];
+					const content = match[3];
+					const contentStart = match.index! + matchText.indexOf(content);
+
+					if (tag === 'style') {
+						sfc.descriptor.styles.push({
+							attrs: {},
+							content,
+							loc: {
+								start: { column: -1, line: -1, offset: contentStart },
+								end: { column: -1, line: -1, offset: contentStart + content.length },
+								source: content,
+							},
+							type: 'style',
+							lang,
+						});
 					}
+					// ignore `<script src="...">`
+					else if (tag === 'script' && attrs.indexOf('src=') === -1) {
+						let type: 'script' | 'scriptSetup' = attrs.indexOf('type=') >= 0 ? 'scriptSetup' : 'script';
+						sfc.descriptor[type] = {
+							attrs: {},
+							content,
+							loc: {
+								start: { column: -1, line: -1, offset: contentStart },
+								end: { column: -1, line: -1, offset: contentStart + content.length },
+								source: content,
+							},
+							type: 'script',
+							lang,
+						};
+					}
+
+					templateContent = templateContent.substring(0, match.index) + ' '.repeat(matchText.length) + templateContent.substring(match.index! + matchText.length);
 				}
 
-				newContent = newContent.replace(/<script[\s\S]*?>/g, str => `<vls-sr${' '.repeat(str.length - '<script>'.length)}>`);
-				newContent = newContent.replace(/<\/script>/g, '</vls-sr>');
-
-				codeGen.addText('<template>\n');
-				codeGen.addCode2(newContent, 0, undefined);
-				codeGen.addText('\n</template>');
-
-				if (isTs) {
-					codeGen.addText('\n<script setup lang="ts"></script>');
-				}
-
-				const file2VueSourceMap = new SourceMapBase(codeGen.mappings);
-				const sfc = parse(codeGen.getText(), { sourceMap: false, ignoreEmpty: false });
-
-				if (sfc.descriptor.template) {
-					transformRange(sfc.descriptor.template);
-				}
-				if (sfc.descriptor.script) {
-					transformRange(sfc.descriptor.script);
-				}
-				if (sfc.descriptor.scriptSetup) {
-					transformRange(sfc.descriptor.scriptSetup);
-				}
-				for (const style of sfc.descriptor.styles) {
-					transformRange(style);
-				}
-				for (const customBlock of sfc.descriptor.customBlocks) {
-					transformRange(customBlock);
-				}
+				sfc.descriptor.template = {
+					attrs: {},
+					content: templateContent,
+					loc: {
+						start: { column: -1, line: -1, offset: 0 },
+						end: { column: -1, line: -1, offset: templateContent.length },
+						source: templateContent,
+					},
+					type: 'template',
+					ast: {} as any,
+				};
 
 				return sfc;
-
-				function transformRange(block: SFCBlock) {
-					const fileRange = file2VueSourceMap.getSourceRange(block.loc.start.offset, block.loc.end.offset)?.[0];
-					if (fileRange) {
-						block.loc.start.offset = fileRange.start;
-						block.loc.end.offset = fileRange.end;
-					}
-					else {
-						block.loc.start.offset = -1;
-						block.loc.end.offset = -1;
-					}
-				}
 			};
 		}
 	};
-}
+};
 export = plugin;

--- a/packages/vue-language-server/src/index.ts
+++ b/packages/vue-language-server/src/index.ts
@@ -1,3 +1,4 @@
 export * from '@volar/language-server';
 export * from './requests';
+export * from './types';
 

--- a/packages/vue-language-server/src/plugin.ts
+++ b/packages/vue-language-server/src/plugin.ts
@@ -1,18 +1,10 @@
 import * as embedded from '@volar/language-core';
-import { LanguageServerPlugin, ServerInitializationOptions } from '@volar/language-server';
+import { LanguageServerPlugin } from '@volar/language-server';
 import * as shared from '@volar/shared';
 import * as vue from '@volar/vue-language-service';
 import * as nameCasing from '@volar/vue-language-service/out/ideFeatures/nameCasing';
 import { DetectTagCasingRequest, GetConvertTagCasingEditsRequest } from './requests';
-
-type VueServerInitializationOptions = ServerInitializationOptions & {
-	petiteVue?: {
-		processHtmlFile: boolean,
-	},
-	vitePress?: {
-		processMdFile: boolean,
-	},
-};
+import { VueServerInitializationOptions } from './types';
 
 const plugin: LanguageServerPlugin<VueServerInitializationOptions, vue.LanguageServiceHost> = (initOptions) => {
 

--- a/packages/vue-language-server/src/plugin.ts
+++ b/packages/vue-language-server/src/plugin.ts
@@ -1,69 +1,91 @@
 import * as embedded from '@volar/language-core';
-import { LanguageServerPlugin } from '@volar/language-server';
+import { LanguageServerPlugin, ServerInitializationOptions } from '@volar/language-server';
 import * as shared from '@volar/shared';
 import * as vue from '@volar/vue-language-service';
 import * as nameCasing from '@volar/vue-language-service/out/ideFeatures/nameCasing';
 import { DetectTagCasingRequest, GetConvertTagCasingEditsRequest } from './requests';
 
-const plugin: LanguageServerPlugin<vue.LanguageServiceHost> = {
-	extensions: ['.vue'],
-	// indeterminateExts: ['.md', '.html'],
-	languageService: {
-		semanticTokenLegend: vue.getSemanticTokenLegend(),
-		resolveLanguageServiceHost(ts, sys, tsConfig, host) {
-			let vueOptions: vue.VueCompilerOptions = {};
-			if (typeof tsConfig === 'string') {
-				vueOptions = vue.createParsedCommandLine(ts, sys, tsConfig).vueOptions;
-			}
-			return {
-				...host,
-				getVueCompilationSettings: () => vueOptions,
-			};
-		},
-		getLanguageModules(host) {
-			const vueLanguageModule = vue.createEmbeddedLanguageModule(
-				host.getTypeScriptModule(),
-				host.getCurrentDirectory(),
-				host.getCompilationSettings(),
-				host.getVueCompilationSettings(),
-			);
-			return [vueLanguageModule];
-		},
-		getServicePlugins(host, service) {
-			return vue.getLanguageServicePlugins(host, service);
-		},
-		onInitialize(connection, getService) {
-
-			connection.onRequest(DetectTagCasingRequest.type, async params => {
-				const languageService = await getService(params.textDocument.uri);
-				return nameCasing.detect(languageService.context, params.textDocument.uri);
-			});
-
-			connection.onRequest(GetConvertTagCasingEditsRequest.type, async params => {
-				const languageService = await getService(params.textDocument.uri);
-				return nameCasing.convert(languageService.context, languageService.findReferences, params.textDocument.uri, params.casing);
-			});
-		},
+type VueServerInitializationOptions = ServerInitializationOptions & {
+	petiteVue?: {
+		processHtmlFile: boolean,
 	},
-	documentService: {
-		getLanguageModules(ts, env) {
-			const vueLanguagePlugins = vue.getDefaultVueLanguagePlugins(ts, shared.getPathOfUri(env.rootUri.toString()), {}, {}, []);
-			const vueLanguageModule: embedded.EmbeddedLanguageModule = {
-				createSourceFile(fileName, snapshot) {
-					if (fileName.endsWith('.vue')) {
-						return new vue.VueSourceFile(fileName, snapshot, ts, vueLanguagePlugins);
-					}
-				},
-				updateSourceFile(sourceFile: vue.VueSourceFile, snapshot) {
-					sourceFile.update(snapshot);
-				},
-			};
-			return [vueLanguageModule];
-		},
-		getServicePlugins(context) {
-			return vue.getDocumentServicePlugins(context);
-		},
+	vitePress?: {
+		processMdFile: boolean,
 	},
+};
+
+const plugin: LanguageServerPlugin<VueServerInitializationOptions, vue.LanguageServiceHost> = (initOptions) => {
+
+	const extensions = ['.vue'];
+
+	if (initOptions.petiteVue?.processHtmlFile) {
+		extensions.push('.html');
+	}
+
+	if (initOptions.vitePress?.processMdFile) {
+		extensions.push('.md');
+	}
+
+	return {
+		extensions,
+		languageService: {
+			semanticTokenLegend: vue.getSemanticTokenLegend(),
+			resolveLanguageServiceHost(ts, sys, tsConfig, host) {
+				let vueOptions: vue.VueCompilerOptions = {};
+				if (typeof tsConfig === 'string') {
+					vueOptions = vue.createParsedCommandLine(ts, sys, tsConfig).vueOptions;
+				}
+				return {
+					...host,
+					getVueCompilationSettings: () => vueOptions,
+				};
+			},
+			getLanguageModules(host) {
+				const vueLanguageModule = vue.createEmbeddedLanguageModule(
+					host.getTypeScriptModule(),
+					host.getCurrentDirectory(),
+					host.getCompilationSettings(),
+					host.getVueCompilationSettings(),
+					extensions,
+				);
+				return [vueLanguageModule];
+			},
+			getServicePlugins(host, service) {
+				return vue.getLanguageServicePlugins(host, service);
+			},
+			onInitialize(connection, getService) {
+
+				connection.onRequest(DetectTagCasingRequest.type, async params => {
+					const languageService = await getService(params.textDocument.uri);
+					return nameCasing.detect(languageService.context, params.textDocument.uri);
+				});
+
+				connection.onRequest(GetConvertTagCasingEditsRequest.type, async params => {
+					const languageService = await getService(params.textDocument.uri);
+					return nameCasing.convert(languageService.context, languageService.findReferences, params.textDocument.uri, params.casing);
+				});
+			},
+		},
+		documentService: {
+			getLanguageModules(ts, env) {
+				const vueLanguagePlugins = vue.getDefaultVueLanguagePlugins(ts, shared.getPathOfUri(env.rootUri.toString()), {}, {}, []);
+				const vueLanguageModule: embedded.EmbeddedLanguageModule = {
+					createSourceFile(fileName, snapshot) {
+						if (extensions.some(ext => fileName.endsWith(ext))) {
+							return new vue.VueSourceFile(fileName, snapshot, ts, vueLanguagePlugins);
+						}
+					},
+					updateSourceFile(sourceFile: vue.VueSourceFile, snapshot) {
+						sourceFile.update(snapshot);
+					},
+				};
+				return [vueLanguageModule];
+			},
+			getServicePlugins(context) {
+				return vue.getDocumentServicePlugins(context);
+			},
+		},
+	};
 };
 
 export = plugin;

--- a/packages/vue-language-server/src/types.ts
+++ b/packages/vue-language-server/src/types.ts
@@ -1,0 +1,10 @@
+import { ServerInitializationOptions } from "@volar/language-server";
+
+export type VueServerInitializationOptions = ServerInitializationOptions & {
+	petiteVue?: {
+		processHtmlFile: boolean,
+	},
+	vitePress?: {
+		processMdFile: boolean,
+	},
+};

--- a/packages/vue-language-service/src/documentService.ts
+++ b/packages/vue-language-service/src/documentService.ts
@@ -52,6 +52,7 @@ export function createDocumentService(
 		env.rootUri.fsPath,
 		{},
 		{},
+		['.vue'],
 	);
 	const languageServiceContext = embeddedLS.getDocumentServiceContext({
 		ts,

--- a/packages/vue-language-service/src/languageService.ts
+++ b/packages/vue-language-service/src/languageService.ts
@@ -128,6 +128,7 @@ export function createLanguageService(
 		host.getCurrentDirectory(),
 		host.getCompilationSettings(),
 		host.getVueCompilationSettings(),
+		['.vue'],
 	);
 	const core = embedded.createEmbeddedLanguageServiceHost(host, [vueLanguageModule]);
 	const languageServiceContext = embeddedLS.createLanguageServiceContext({

--- a/packages/vue-typescript/src/index.ts
+++ b/packages/vue-typescript/src/index.ts
@@ -11,6 +11,7 @@ export function createLanguageService(host: vue.LanguageServiceHost) {
 		host.getCurrentDirectory(),
 		host.getCompilationSettings(),
 		host.getVueCompilationSettings(),
+		['.vue']
 	)];
 	const core = embedded.createEmbeddedLanguageServiceHost(host, mods);
 	const ts = host.getTypeScriptModule();


### PR DESCRIPTION
To enable language support for petite-vue / VitePress, you need to setting `"volar.vueserver.petiteVue.processHtmlFile": true`, `"volar.vueserver.vitePress.processMdFile": true` in workspace VSCode settings.

close #1471, close #1852