### PR TITLE
Add less support for initial indent in non-template regions

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -408,6 +408,10 @@
 							"type": "boolean",
 							"default": false
 						},
+						"less": {
+							"type": "boolean",
+							"default": false
+						},						
 						"json": {
 							"type": "boolean",
 							"default": false

--- a/packages/vue-language-core/src/plugins/vue-sfc-styles.ts
+++ b/packages/vue-language-core/src/plugins/vue-sfc-styles.ts
@@ -3,6 +3,7 @@ import { VueLanguagePlugin } from '../types';
 const presetInitialIndentBrackets: Record<string, [string, string] | undefined> = {
 	css: ['{', '}'],
 	scss: ['{', '}'],
+	less: ['{', '}'],
 };
 
 const plugin: VueLanguagePlugin = () => {


### PR DESCRIPTION
Less support was left out in the initial pull request https://github.com/johnsoncodehk/volar/pull/1822

This pull request corrects that