### PR TITLE
perf: reduce VueSourceFile overhead memory usage

### DIFF
--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -561,13 +561,12 @@ export function generate(
 	}
 	function writeExportOptions() {
 		codeGen.addText(`\n`);
-		codeGen.addText(`const __VLS_options = {\n`);
-		if (sfc.script && scriptRanges?.exportDefault?.args) {
-			const args = scriptRanges.exportDefault.args;
-			codeGen.addText(`...(`);
+		codeGen.addText(`const __VLS_componentsOption = `);
+		if (sfc.script && scriptRanges?.exportDefault?.componentsOption) {
+			const componentsOption = scriptRanges.exportDefault.componentsOption;
 			codeGen.addCode2(
-				sfc.script.content.substring(args.start, args.end),
-				args.start,
+				sfc.script.content.substring(componentsOption.start, componentsOption.end),
+				componentsOption.start,
 				{
 					vueTag: 'script',
 					capabilities: {
@@ -576,9 +575,11 @@ export function generate(
 					},
 				},
 			);
-			codeGen.addText(`),\n`);
 		}
-		codeGen.addText(`};\n`);
+		else {
+			codeGen.addText('{}');
+		}
+		codeGen.addText(`;\n`);
 	}
 	function writeConstNameOption() {
 		codeGen.addText(`\n`);
@@ -622,11 +623,9 @@ export function generate(
 		}
 		codeGen.addText(`};\n`);
 
-		codeGen.addText(`let __VLS_vmUnwrap!: typeof __VLS_options & { components: { } };\n`);
-
 		/* Components */
 		codeGen.addText('/* Components */\n');
-		codeGen.addText(`let __VLS_otherComponents!: NonNullable<typeof __VLS_component extends { components: infer C } ? C : {}> & import('./__VLS_types.js').GlobalComponents & typeof __VLS_vmUnwrap.components & import('./__VLS_types.js').PickComponents<typeof __VLS_ctx>;\n`);
+		codeGen.addText(`let __VLS_otherComponents!: NonNullable<typeof __VLS_component extends { components: infer C } ? C : {}> & import('./__VLS_types.js').GlobalComponents & typeof __VLS_componentsOption & import('./__VLS_types.js').PickComponents<typeof __VLS_ctx>;\n`);
 		codeGen.addText(`let __VLS_selfComponent!: import('./__VLS_types.js').SelfComponent<typeof __VLS_name, typeof __VLS_component & (new () => { ${getSlotsPropertyName(vueCompilerOptions.target ?? 3)}: typeof __VLS_slots })>;\n`);
 		codeGen.addText(`let __VLS_components!: typeof __VLS_otherComponents & Omit<typeof __VLS_selfComponent, keyof typeof __VLS_otherComponents>;\n`);
 

--- a/packages/vue-language-core/src/generators/script.ts
+++ b/packages/vue-language-core/src/generators/script.ts
@@ -582,11 +582,11 @@ export function generate(
 	}
 	function writeConstNameOption() {
 		codeGen.addText(`\n`);
-		if (sfc.script && scriptRanges?.exportDefault?.args) {
-			const args = scriptRanges.exportDefault.args;
-			codeGen.addText(`const __VLS_name = (await import('./__VLS_types.js')).getNameOption(`);
-			codeGen.addText(`${sfc.script.content.substring(args.start, args.end)} as const`);
-			codeGen.addText(`);\n`);
+		if (sfc.script && scriptRanges?.exportDefault?.nameOption) {
+			const nameOption = scriptRanges.exportDefault.nameOption;
+			codeGen.addText(`const __VLS_name = `);
+			codeGen.addText(`${sfc.script.content.substring(nameOption.start, nameOption.end)} as const`);
+			codeGen.addText(`;\n`);
 		}
 		else if (sfc.scriptSetup) {
 			codeGen.addText(`let __VLS_name!: '${path.basename(fileName.substring(0, fileName.lastIndexOf('.')))}';\n`);

--- a/packages/vue-language-core/src/generators/template.ts
+++ b/packages/vue-language-core/src/generators/template.ts
@@ -251,24 +251,14 @@ export function generate(
 				}
 			}
 
-			const componentNames = new Set([
-				tagName, // hello-world
-				camelize(tagName), // helloWorld
-				capitalize(camelize(tagName)), // HelloWorld
-			]);
-
 			/* Completion */
 			codeGen.addText('/* Completion: Emits */\n');
-			for (const name of componentNames) {
-				codeGen.addText('// @ts-ignore\n');
-				codeGen.addText(`({} as import('./__VLS_types.js').ExtractEmit2<typeof ${var_componentVar}>)('${SearchTexts.EmitCompletion(name)}');\n`);
-			}
+			codeGen.addText('// @ts-ignore\n');
+			codeGen.addText(`({} as import('./__VLS_types.js').ExtractEmit2<typeof ${var_componentVar}>)('${SearchTexts.EmitCompletion(tagName)}');\n`);
 
 			codeGen.addText('/* Completion: Props */\n');
-			for (const name of componentNames) {
-				codeGen.addText('// @ts-ignore\n');
-				codeGen.addText(`({} as import('./__VLS_types.js').ExtractProps<typeof ${var_componentVar}>)['${SearchTexts.PropsCompletion(name)}'];\n`);
-			}
+			codeGen.addText('// @ts-ignore\n');
+			codeGen.addText(`({} as import('./__VLS_types.js').ExtractProps<typeof ${var_componentVar}>)['${SearchTexts.PropsCompletion(tagName)}'];\n`);
 
 			data[tagName] = {
 				component: var_componentVar,

--- a/packages/vue-language-core/src/parsers/scriptRanges.ts
+++ b/packages/vue-language-core/src/parsers/scriptRanges.ts
@@ -4,7 +4,7 @@ import { getStartEnd, parseBindingRanges } from './scriptSetupRanges';
 
 export interface ScriptRanges extends ReturnType<typeof parseScriptRanges> { }
 
-export function parseScriptRanges(ts: typeof import('typescript/lib/tsserverlibrary'), ast: ts.SourceFile, hasScriptSetup: boolean, withComponentOption: boolean, withNode: boolean) {
+export function parseScriptRanges(ts: typeof import('typescript/lib/tsserverlibrary'), ast: ts.SourceFile, hasScriptSetup: boolean, withNode: boolean) {
 
 	let exportDefault: (TextRange & {
 		expression: TextRange,
@@ -12,6 +12,7 @@ export function parseScriptRanges(ts: typeof import('typescript/lib/tsserverlibr
 		argsNode: ts.ObjectLiteralExpression | undefined,
 		componentsOption: TextRange | undefined,
 		componentsOptionNode: ts.ObjectLiteralExpression | undefined,
+		nameOption: TextRange | undefined,
 	}) | undefined;
 
 	const bindings = hasScriptSetup ? parseBindingRanges(ts, ast, false) : [];
@@ -30,15 +31,17 @@ export function parseScriptRanges(ts: typeof import('typescript/lib/tsserverlibr
 			}
 			if (obj) {
 				let componentsOptionNode: ts.ObjectLiteralExpression | undefined;
-				if (withComponentOption) {
-					obj.forEachChild(node => {
-						if (ts.isPropertyAssignment(node) && ts.isIdentifier(node.name)) {
-							if (node.name.escapedText === 'components' && ts.isObjectLiteralExpression(node.initializer)) {
-								componentsOptionNode = node.initializer;
-							}
+				let nameOptionNode: ts.Expression | undefined;
+				obj.forEachChild(node => {
+					if (ts.isPropertyAssignment(node) && ts.isIdentifier(node.name)) {
+						if (node.name.escapedText === 'components' && ts.isObjectLiteralExpression(node.initializer)) {
+							componentsOptionNode = node.initializer;
 						}
-					});
-				}
+						if (node.name.escapedText === 'name') {
+							nameOptionNode = node.initializer;
+						}
+					}
+				});
 				exportDefault = {
 					..._getStartEnd(node),
 					expression: _getStartEnd(node.expression),
@@ -46,6 +49,7 @@ export function parseScriptRanges(ts: typeof import('typescript/lib/tsserverlibr
 					argsNode: withNode ? obj : undefined,
 					componentsOption: componentsOptionNode ? _getStartEnd(componentsOptionNode) : undefined,
 					componentsOptionNode: withNode ? componentsOptionNode : undefined,
+					nameOption: nameOptionNode ? _getStartEnd(nameOptionNode) : undefined,
 				};
 			}
 		}

--- a/packages/vue-language-core/src/plugins/vue-tsx.ts
+++ b/packages/vue-language-core/src/plugins/vue-tsx.ts
@@ -31,7 +31,7 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 	const cssVars = computed(() => collectCssVars(_sfc.value));
 	const scriptRanges = computed(() =>
 		_sfc.value.scriptAst
-			? parseScriptRanges(ts, _sfc.value.scriptAst, !!_sfc.value.scriptSetup, false, false)
+			? parseScriptRanges(ts, _sfc.value.scriptAst, !!_sfc.value.scriptSetup, false)
 			: undefined
 	);
 	const scriptSetupRanges = computed(() =>

--- a/packages/vue-language-core/src/plugins/vue-tsx.ts
+++ b/packages/vue-language-core/src/plugins/vue-tsx.ts
@@ -1,4 +1,4 @@
-import { computed } from '@vue/reactivity';
+import { computed, shallowRef as ref } from '@vue/reactivity';
 import { generate as genScript } from '../generators/script';
 import * as templateGen from '../generators/template';
 import { parseScriptRanges } from '../parsers/scriptRanges';
@@ -11,17 +11,82 @@ import { parseCssVars } from '../utils/parseCssVars';
 const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOptions }) => {
 
 	const ts = modules.typescript;
-	const gen = new WeakMap<Sfc, ReturnType<typeof createGen>>();
+	const _fileName = ref('');
+	const _sfc = ref<Sfc>({} as any);
+	const lang = computed(() => {
+		let lang = !_sfc.value.script && !_sfc.value.scriptSetup ? 'ts'
+			: _sfc.value.scriptSetup && _sfc.value.scriptSetup.lang !== 'js' ? _sfc.value.scriptSetup.lang
+				: _sfc.value.script && _sfc.value.script.lang !== 'js' ? _sfc.value.script.lang
+					: 'js';
+		if (vueCompilerOptions.jsxTemplates) {
+			if (lang === 'js') {
+				lang = 'jsx';
+			}
+			else if (lang === 'ts') {
+				lang = 'tsx';
+			}
+		}
+		return lang;
+	});
+	const cssVars = computed(() => collectCssVars(_sfc.value));
+	const scriptRanges = computed(() =>
+		_sfc.value.scriptAst
+			? parseScriptRanges(ts, _sfc.value.scriptAst, !!_sfc.value.scriptSetup, false, false)
+			: undefined
+	);
+	const scriptSetupRanges = computed(() =>
+		_sfc.value.scriptSetupAst
+			? parseScriptSetupRanges(ts, _sfc.value.scriptSetupAst)
+			: undefined
+	);
+	const cssModuleClasses = computed(() => collectStyleCssClasses(_sfc.value, style => !!style.module));
+	const cssScopedClasses = computed(() => collectStyleCssClasses(_sfc.value, style => {
+		const setting = vueCompilerOptions.experimentalResolveStyleCssClasses;
+		return (setting === 'scoped' && style.scoped) || setting === 'always';
+	}));
+	const htmlGen = computed(() => {
+
+		const templateAst = _sfc.value.getTemplateAst();
+
+		if (!templateAst)
+			return;
+		
+		return templateGen.generate(
+			ts,
+			vueCompilerOptions,
+			_sfc.value.template?.content ?? '',
+			_sfc.value.template?.lang ?? 'html',
+			templateAst,
+			!!_sfc.value.scriptSetup,
+			Object.values(cssScopedClasses.value).map(style => style.classNames).flat(),
+		);
+	});
+	const tsxGen = computed(() => genScript(
+		ts,
+		_fileName.value,
+		_sfc.value,
+		lang.value,
+		scriptRanges.value,
+		scriptSetupRanges.value,
+		cssVars.value,
+		cssModuleClasses.value,
+		cssScopedClasses.value,
+		htmlGen.value,
+		compilerOptions,
+		vueCompilerOptions,
+	));
 
 	return {
 
 		getEmbeddedFileNames(fileName, sfc) {
 
-			const fileNames: string[] = [];
-			const _gen = useGen(fileName, sfc);
+			_fileName.value = fileName;
+			_sfc.value = sfc;
 
-			if (_gen?.lang.value && ['js', 'ts', 'jsx', 'tsx'].includes(_gen.lang.value)) {
-				fileNames.push(fileName + '.' + _gen.lang.value);
+			const fileNames: string[] = [];
+
+			if (['js', 'ts', 'jsx', 'tsx'].includes(lang.value)) {
+				fileNames.push(fileName + '.' + lang.value);
 			}
 
 			if (sfc.template) {
@@ -33,9 +98,13 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 		},
 
 		resolveEmbeddedFile(fileName, sfc, embeddedFile) {
+
+			_fileName.value = fileName;
+			_sfc.value = sfc;
+
 			const suffix = embeddedFile.fileName.replace(fileName, '');
-			const _gen = useGen(fileName, sfc);
-			if (suffix === '.' + _gen?.lang.value) {
+
+			if (suffix === '.' + lang.value) {
 				embeddedFile.isTsHostFile = true;
 				embeddedFile.capabilities = {
 					diagnostics: true,
@@ -45,8 +114,9 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 					codeActions: true,
 					inlayHints: true,
 				};
-				const tsx = _gen?.tsxGen.value;
+				const tsx = tsxGen.value;
 				if (tsx) {
+					console.log(embeddedFile.fileName, sfc.script?.content.length, tsx.codeGen.getText().length);
 					embeddedFile.codeGen.addText(tsx.codeGen.getText());
 					embeddedFile.codeGen.mappings = [...tsx.codeGen.mappings];
 					embeddedFile.teleportMappings = [...tsx.teleports];
@@ -65,101 +135,22 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 				};
 				embeddedFile.isTsHostFile = false;
 
-				if (_gen?.htmlGen.value) {
-					embeddedFile.codeGen.addText(_gen.htmlGen.value.formatCodeGen.getText());
-					embeddedFile.codeGen.mappings = [..._gen.htmlGen.value.formatCodeGen.mappings];
+				if (htmlGen.value) {
+					embeddedFile.codeGen.addText(htmlGen.value.formatCodeGen.getText());
+					embeddedFile.codeGen.mappings = [...htmlGen.value.formatCodeGen.mappings];
 				}
 			}
 			else if (suffix.match(/^\.__VLS_template_style\.css$/)) {
 
 				embeddedFile.parentFileName = fileName + '.template.' + sfc.template?.lang;
 
-				if (_gen?.htmlGen.value) {
-					embeddedFile.codeGen.addText(_gen.htmlGen.value.cssCodeGen.getText());
-					embeddedFile.codeGen.mappings = [..._gen.htmlGen.value.cssCodeGen.mappings];
+				if (htmlGen.value) {
+					embeddedFile.codeGen.addText(htmlGen.value.cssCodeGen.getText());
+					embeddedFile.codeGen.mappings = [...htmlGen.value.cssCodeGen.mappings];
 				}
 			}
 		},
 	};
-
-	function useGen(fileName: string, sfc: Sfc) {
-		if (!gen.has(sfc)) {
-			gen.set(sfc, createGen(fileName, sfc));
-		}
-		return gen.get(sfc);
-	}
-
-	function createGen(fileName: string, sfc: Sfc) {
-
-		const lang = computed(() => {
-			let lang = !sfc.script && !sfc.scriptSetup ? 'ts'
-				: sfc.scriptSetup && sfc.scriptSetup.lang !== 'js' ? sfc.scriptSetup.lang
-					: sfc.script && sfc.script.lang !== 'js' ? sfc.script.lang
-						: 'js';
-			if (vueCompilerOptions.jsxTemplates) {
-				if (lang === 'js') {
-					lang = 'jsx';
-				}
-				else if (lang === 'ts') {
-					lang = 'tsx';
-				}
-			}
-			return lang;
-		});
-		const cssVars = computed(() => collectCssVars(sfc));
-		const scriptRanges = computed(() =>
-			sfc.scriptAst
-				? parseScriptRanges(ts, sfc.scriptAst, !!sfc.scriptSetup, false, false)
-				: undefined
-		);
-		const scriptSetupRanges = computed(() =>
-			sfc.scriptSetupAst
-				? parseScriptSetupRanges(ts, sfc.scriptSetupAst)
-				: undefined
-		);
-		const cssModuleClasses = computed(() => collectStyleCssClasses(sfc, style => !!style.module));
-		const cssScopedClasses = computed(() => collectStyleCssClasses(sfc, style => {
-			const setting = vueCompilerOptions.experimentalResolveStyleCssClasses;
-			return (setting === 'scoped' && style.scoped) || setting === 'always';
-		}));
-		const htmlGen = computed(() => {
-			
-			const templateAst = sfc.getTemplateAst();
-
-			if (!templateAst)
-				return;
-
-			return templateGen.generate(
-				ts,
-				vueCompilerOptions,
-				sfc.template?.content ?? '',
-				sfc.template?.lang ?? 'html',
-				templateAst,
-				!!sfc.scriptSetup,
-				Object.values(cssScopedClasses.value).map(style => style.classNames).flat(),
-			);
-		});
-		const tsxGen = computed(() => genScript(
-			ts,
-			fileName,
-			sfc,
-			lang.value,
-			scriptRanges.value,
-			scriptSetupRanges.value,
-			cssVars.value,
-			cssModuleClasses.value,
-			cssScopedClasses.value,
-			htmlGen.value,
-			compilerOptions,
-			vueCompilerOptions,
-		));
-
-		return {
-			lang,
-			htmlGen,
-			tsxGen,
-		};
-	}
 };
 export default plugin;
 

--- a/packages/vue-language-core/src/plugins/vue-tsx.ts
+++ b/packages/vue-language-core/src/plugins/vue-tsx.ts
@@ -123,8 +123,10 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 			return (setting === 'scoped' && style.scoped) || setting === 'always';
 		}));
 		const htmlGen = computed(() => {
+			
+			const templateAst = sfc.getTemplateAst();
 
-			if (!sfc.templateAst)
+			if (!templateAst)
 				return;
 
 			return templateGen.generate(
@@ -132,7 +134,7 @@ const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions, compilerOption
 				vueCompilerOptions,
 				sfc.template?.content ?? '',
 				sfc.template?.lang ?? 'html',
-				sfc.templateAst,
+				templateAst,
 				!!sfc.scriptSetup,
 				Object.values(cssScopedClasses.value).map(style => style.classNames).flat(),
 			);

--- a/packages/vue-language-core/src/types.ts
+++ b/packages/vue-language-core/src/types.ts
@@ -71,7 +71,7 @@ export interface Sfc {
 	})[];
 
 	// ast
-	templateAst: CompilerDom.RootNode | undefined;
+	getTemplateAst: () => CompilerDom.RootNode | undefined;
 	scriptAst: ts.SourceFile | undefined;
 	scriptSetupAst: ts.SourceFile | undefined;
 }

--- a/packages/vue-language-core/src/utils/localTypes.ts
+++ b/packages/vue-language-core/src/utils/localTypes.ts
@@ -42,7 +42,6 @@ export type GlobalComponents =
 	>;
 
 export declare function getVforSourceType<T>(source: T): ForableSource<NonNullable<T extends number ? number[] : T extends string ? string[] : T>>;
-export declare function getNameOption<T>(t?: T): T extends { name: infer N } ? N : undefined;
 export declare function directiveFunction<T>(dir: T):
 	T extends ObjectDirective<infer E, infer V> ? undefined extends V ? (value?: V) => void : (value: V) => void
 	: T extends FunctionDirective<infer E, infer V> ? undefined extends V ? (value?: V) => void : (value: V) => void

--- a/packages/vue-language-core/src/utils/string.ts
+++ b/packages/vue-language-core/src/utils/string.ts
@@ -1,6 +1,8 @@
+import { hyphenate } from '@vue/shared';
+
 export const SearchTexts = {
 	Components: '/* __VLS_.SearchTexts.Components */',
 	GlobalAttrs: '/* __VLS_.SearchTexts.GlobalAttrs */',
-	PropsCompletion: (tag: string) => `/* __VLS_.SearchTexts.Completion.Props.${tag} */`,
-	EmitCompletion: (tag: string) => `/* __VLS_.SearchTexts.Completion.Emit.${tag} */`,
+	PropsCompletion: (tag: string) => `/* __VLS_.SearchTexts.Completion.Props.${hyphenate(tag)} */`,
+	EmitCompletion: (tag: string) => `/* __VLS_.SearchTexts.Completion.Emit.${hyphenate(tag)} */`,
 };

--- a/packages/vue-language-service/src/plugins/vue-template.ts
+++ b/packages/vue-language-service/src/plugins/vue-template.ts
@@ -350,7 +350,7 @@ export default function useVueTemplateLanguagePlugin<T extends ReturnType<typeof
 					'\n' + insert.insertText,
 				),
 			];
-			const _scriptRanges = vue.scriptRanges.parseScriptRanges(ts, sfc.scriptAst, !!sfc.scriptSetup, true, true);
+			const _scriptRanges = vue.scriptRanges.parseScriptRanges(ts, sfc.scriptAst, !!sfc.scriptSetup, true);
 			const exportDefault = _scriptRanges.exportDefault;
 			if (exportDefault) {
 				// https://github.com/microsoft/TypeScript/issues/36174


### PR DESCRIPTION
When project include lot of vue files, cache template AST / SFC parse result / codegen data memory overhead is high, it is necessary for better DX, but we can only cache for last editing vue file instead of cache for all project vue files.

