### PR TITLE
doc: update reference to the takeover mode in the Vue docs

### DIFF
--- a/extensions/vscode-vue-language-features/src/features/tsVersion.ts
+++ b/extensions/vscode-vue-language-features/src/features/tsVersion.ts
@@ -44,7 +44,7 @@ export async function register(cmd: string, context: vscode.ExtensionContext, cl
 			return; // cancel
 		}
 		if (select === 'takeover') {
-			vscode.env.openExternal(vscode.Uri.parse('https://vuejs.org/guide/typescript/overview.html#takeover-mode'));
+			vscode.env.openExternal(vscode.Uri.parse('https://vuejs.org/guide/typescript/overview.html#volar-takeover-mode'));
 			return;
 		}
 		if (select === 'use_workspace_tsdk_deafult') {


### PR DESCRIPTION
When clicking the `What's is Takeover Mode` option in VSCode, it navigates to the top of the overview page instead of the Volar Takeover Mode section.