### PR TITLE
feat(doctor): added more postcss syntax highliters

### DIFF
--- a/extensions/vscode-vue-language-features/src/features/doctor.ts
+++ b/extensions/vscode-vue-language-features/src/features/doctor.ts
@@ -5,7 +5,7 @@ import { GetMatchTsConfigRequest, ParseSFCRequest } from '@volar/vue-language-se
 
 const scheme = 'vue-doctor';
 const knownValidSyntanxHighlightExtensions = {
-	postcss: ['cpylua.language-postcss'],
+	postcss: ['cpylua.language-postcss', 'vunguyentuan.vscode-postcss', 'csstools.postcss'],
 	stylus: ['sysoev.language-stylus'],
 	sass: ['Syler.sass-indented'],
 };


### PR DESCRIPTION
Added csstools.postcss and vunguyentuan.vscode-postcss as alternative PostCSS syntax highlighters.