### PR TITLE
feat: Support RFC 436 (Experimental)

### DIFF
--- a/vue-language-tools/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/vue-language-tools/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -90,6 +90,11 @@
 						"never"
 					],
 					"markdownDescription": "https://github.com/johnsoncodehk/volar/issues/1038, https://github.com/johnsoncodehk/volar/issues/1121"
+				},
+				"experimentalRfc436": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "https://github.com/vuejs/rfcs/discussions/436"
 				}
 			}
 		}

--- a/vue-language-tools/vue-language-core/src/sourceFile.ts
+++ b/vue-language-tools/vue-language-core/src/sourceFile.ts
@@ -440,6 +440,7 @@ export class VueSourceFile implements SourceFile {
 				endTagStart: block.loc.end.offset,
 				content: block.content,
 				lang: block.lang ?? 'js',
+				generic: typeof block.attrs.generic === 'string' ? block.attrs.generic : undefined,
 			} : null;
 
 			if (self.sfc.scriptSetup && newData) {

--- a/vue-language-tools/vue-language-core/src/types.ts
+++ b/vue-language-tools/vue-language-core/src/types.ts
@@ -30,6 +30,7 @@ export interface ResolvedVueCompilerOptions {
 	experimentalTemplateCompilerOptions: any;
 	experimentalTemplateCompilerOptionsRequirePath: string | undefined;
 	experimentalResolveStyleCssClasses: 'scoped' | 'always' | 'never';
+	experimentalRfc436: boolean;
 }
 
 export type VueLanguagePlugin = (ctx: {
@@ -66,7 +67,10 @@ export interface Sfc {
 	script: (SfcBlock & {
 		src: string | undefined;
 	}) | null;
-	scriptSetup: SfcBlock | null;
+	scriptSetup: SfcBlock & {
+		// https://github.com/vuejs/rfcs/discussions/436
+		generic: string | undefined;
+	} | null;
 	styles: (SfcBlock & {
 		module: string | undefined;
 		scoped: boolean;

--- a/vue-language-tools/vue-language-core/src/utils/ts.ts
+++ b/vue-language-tools/vue-language-core/src/utils/ts.ts
@@ -98,6 +98,7 @@ export function resolveVueCompilerOptions(vueOptions: VueCompilerOptions): Resol
 		experimentalTemplateCompilerOptions: vueOptions.experimentalTemplateCompilerOptions ?? {},
 		experimentalTemplateCompilerOptionsRequirePath: vueOptions.experimentalTemplateCompilerOptionsRequirePath ?? undefined,
 		experimentalResolveStyleCssClasses: vueOptions.experimentalResolveStyleCssClasses ?? 'scoped',
+		experimentalRfc436: vueOptions.experimentalRfc436 ?? false,
 	};
 }
 


### PR DESCRIPTION
RFC: https://github.com/vuejs/rfcs/discussions/436

## Usage

```jsonc
{
  "vueCompilerOptions": {
    "jsxTemplates": true,
    "experimentalRfc436": true
  }
}
```

Please note that `extends any` is required, otherwise JSX syntax will be broken.

```html
<script setup lang="ts" generic="T extends any">
defineProps<{ msg: T }>()
</script>
```