### PR TITLE
feat: Support generic typed template slots for RFC 436

### DIFF
--- a/vue-language-tools/vue-language-core/src/generators/script.ts
+++ b/vue-language-tools/vue-language-core/src/generators/script.ts
@@ -242,12 +242,12 @@ export function generate(
 					0,
 					{ diagnostic: true },
 				]);
-				codeGen.push('export default (');
+				codeGen.push('export default ');
 			}
 			if (vueCompilerOptions.experimentalRfc436 && sfc.scriptSetup.generic) {
 				codeGen.push(`<${sfc.scriptSetup.generic}>`);
 			}
-			codeGen.push('(');
+			codeGen.push('((');
 			if (scriptSetupRanges.propsTypeArg) {
 				codeGen.push('__VLS_props: ');
 				addVirtualCode('scriptSetup', scriptSetupRanges.propsTypeArg.start, scriptSetupRanges.propsTypeArg.end);
@@ -398,10 +398,9 @@ export function generate(
 			else {
 				codeGen.push(`return {} as typeof __VLS_Component`);
 				if (htmlGen?.slotsNum) {
-					codeGen.push(` & { new (): { $slots: ReturnType<typeof __VLS_template> }`);
+					codeGen.push(` & { new (): { $slots: ReturnType<typeof __VLS_template> } }`);
 				}
 				codeGen.push(`;\n`);
-				codeGen.push(`};\n`);
 			}
 			codeGen.push(`};\n`);
 			codeGen.push(`return {} as unknown as Awaited<ReturnType<typeof __VLS_setup>>;\n`);

--- a/vue-language-tools/vue-language-core/src/utils/localTypes.ts
+++ b/vue-language-tools/vue-language-core/src/utils/localTypes.ts
@@ -53,16 +53,18 @@ export declare function directiveFunction<T>(dir: T):
 export declare function withScope<T, K>(ctx: T, scope: K): ctx is T & K;
 export declare function makeOptional<T>(t: T): { [K in keyof T]?: T[K] };
 
+// TODO: make it stricter between class component type and functional component type
 export type ExtractComponentSlots<T> =
 	IsAny<T> extends true ? Record<string, any>
 	: T extends { ${slots}?: infer S } ? { [K in keyof S]-?: S[K] extends ((obj: infer O) => any) | undefined ? O : any }
+	: T extends { children?: infer S } ? { [K in keyof S]-?: S[K] extends ((obj: infer O) => any) | undefined ? O : any }
 	: Record<string, any>;
 
 export type FillingEventArg_ParametersLength<E extends (...args: any) => any> = IsAny<Parameters<E>> extends true ? -1 : Parameters<E>['length'];
 export type FillingEventArg<E> = E extends (...args: any) => any ? FillingEventArg_ParametersLength<E> extends 0 ? ($event?: undefined) => ReturnType<E> : E : E;
 
 export type ExtractProps<T> =
-	T extends FunctionalComponent<infer P> ? P
+	T extends (...args: any) => { props: infer Props } ? Props
 	: T extends new (...args: any) => { $props: infer Props } ? Props
 	: T; // IntrinsicElement
 export type ReturnVoid<T> = T extends (...payload: infer P) => any ? (...payload: P) => void : (...args: any) => void;


### PR DESCRIPTION
Update codegen for script setup to change export component type from `DefineComponent` to functional component.

For following SFC code:

```html
<template>
  <slot name="default" :test="props.msg"></slot>
</template>

<script lang="ts" setup generic="T">
const props = defineProps<{ msg: T }>()
</script>
```

Output type:

```ts
<T>(__props: { msg: T }): {
	props: typeof __props,
	children: { default(_: { test: T }): any },
}
```

`vue-component-meta` tests is broken because we not yet implement type extract for functional component in `vue-component-meta`.