### PR TITLE
refactor: remove `experimentalTemplateCompilerOptions`

### DIFF
--- a/vue-language-tools/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/vue-language-tools/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -75,14 +75,6 @@
 					],
 					"markdownDescription": "Run app in browser or uni-app"
 				},
-				"experimentalTemplateCompilerOptions": {
-					"type": "object",
-					"markdownDescription": "https://github.com/johnsoncodehk/volar/issues/576"
-				},
-				"experimentalTemplateCompilerOptionsRequirePath": {
-					"type": "string",
-					"markdownDescription": "https://github.com/johnsoncodehk/volar/issues/698"
-				},
 				"experimentalResolveStyleCssClasses": {
 					"enum": [
 						"scoped",

--- a/vue-language-tools/vue-language-core/src/plugins/vue-template-html.ts
+++ b/vue-language-tools/vue-language-core/src/plugins/vue-template-html.ts
@@ -8,18 +8,11 @@ interface Loc {
 }
 type Node = CompilerDOM.RootNode | CompilerDOM.TemplateChildNode | CompilerDOM.ExpressionNode | CompilerDOM.AttributeNode | CompilerDOM.DirectiveNode;
 
-const plugin: VueLanguagePlugin = ({ modules, vueCompilerOptions }) => {
+const plugin: VueLanguagePlugin = ({ modules }) => {
 
 	return {
 
 		version: 1,
-
-		resolveTemplateCompilerOptions(options) {
-			return {
-				...options,
-				...vueCompilerOptions.experimentalTemplateCompilerOptions,
-			};
-		},
 
 		compileSFCTemplate(lang, template, options) {
 

--- a/vue-language-tools/vue-language-core/src/types.ts
+++ b/vue-language-tools/vue-language-core/src/types.ts
@@ -27,8 +27,6 @@ export interface ResolvedVueCompilerOptions {
 
 	// experimental
 	experimentalRuntimeMode: 'runtime-dom' | 'runtime-uni-app';
-	experimentalTemplateCompilerOptions: any;
-	experimentalTemplateCompilerOptionsRequirePath: string | undefined;
 	experimentalResolveStyleCssClasses: 'scoped' | 'always' | 'never';
 	experimentalRfc436: boolean;
 }


### PR DESCRIPTION
Due to we have add `resolveTemplateCompilerOptions` API for VueLanguagePlugin (https://github.com/johnsoncodehk/volar/commit/079e9ba9d37010bb3b36f6219ca85d76cb308ab7), `experimentalTemplateCompilerOptions` and `experimentalTemplateCompilerOptionsRequirePath` will be remove in `vueCompilerOptions`.

## Migrate

- `tsconfig.json`
```diff
{
	"vueCompilerOptins": {
-		"experimentalTemplateCompilerOptionsRequirePath": "./myOptions.js",
+		"plugins": ["./myOptions.js"],
	}
}
```

- `myOptions.js`
```diff
-export deault { /* my options */ };
+ module.exports = () => ({
+	version: 1,
+	resolveTemplateCompilerOptions(originalOptions) {
+		return {
+			...originalOptions,
+			/* my options */
+		};
+	},
+});
```

cc @theolavaux, @fletcherhaz