### PR TITLE
feat: support `volar.vueserver.json.customBlockSchemaUrls`

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -299,6 +299,9 @@
 					"type": "boolean",
 					"default": false
 				},
+				"volar.vueserver.json.customBlockSchemaUrls": {
+					"type": "object"
+				},
 				"volar.vueserver.textDocumentSync": {
 					"type": "string",
 					"default": "incremental",

--- a/extensions/vscode-vue-language-features/src/common.ts
+++ b/extensions/vscode-vue-language-features/src/common.ts
@@ -278,6 +278,9 @@ function getInitializationOptions(
 		vitePress: {
 			processMdFile: processMd(),
 		},
+		json: {
+			customBlockSchemaUrls: vscode.workspace.getConfiguration('volar').get<Record<string, string>>('vueserver.json.customBlockSchemaUrls')
+		},
 		noProjectReferences: noProjectReferences(),
 		additionalExtensions: additionalExtensions()
 	};

--- a/plugins/json/src/index.ts
+++ b/plugins/json/src/index.ts
@@ -3,7 +3,7 @@ import * as json from 'vscode-json-languageservice';
 import * as vscode from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
-export default function (): LanguageServicePlugin {
+export default function (settings?: json.LanguageSettings): LanguageServicePlugin {
 
 	const jsonDocuments = new WeakMap<TextDocument, [number, json.JSONDocument]>();
 
@@ -15,6 +15,9 @@ export default function (): LanguageServicePlugin {
 		setup(_context) {
 			context = _context;
 			jsonLs = json.getLanguageService({ schemaRequestService: _context.env.schemaRequestService });
+			if (settings) {
+				jsonLs.configure(settings);
+			}
 		},
 
 		complete: {

--- a/vue-language-tools/vue-language-server/src/languageServerPlugin.ts
+++ b/vue-language-tools/vue-language-server/src/languageServerPlugin.ts
@@ -51,7 +51,18 @@ const plugin: LanguageServerPlugin<VueServerInitializationOptions, vue.LanguageS
 				return [vueLanguageModule];
 			},
 			getServicePlugins(host, service) {
-				return vue.getLanguageServicePlugins(host, service);
+				const settings: vue.Settings = {};
+				if (initOptions.json) {
+					settings.json = { schemas: [] };
+					for (const blockType in initOptions.json.customBlockSchemaUrls) {
+						const url = initOptions.json.customBlockSchemaUrls[blockType];
+						settings.json.schemas?.push({
+							fileMatch: [`*.customBlock_${blockType}_*.json*`],
+							uri: new URL(url, service.context.pluginContext.env.rootUri.toString() + '/').toString(),
+						});
+					}
+				}
+				return vue.getLanguageServicePlugins(host, service, settings);
 			},
 			onInitialize(connection, getService) {
 

--- a/vue-language-tools/vue-language-server/src/types.ts
+++ b/vue-language-tools/vue-language-server/src/types.ts
@@ -2,13 +2,16 @@ import { LanguageServerInitializationOptions } from "@volar/language-server";
 
 export type VueServerInitializationOptions = LanguageServerInitializationOptions & {
 	petiteVue?: {
-		processHtmlFile: boolean,
-	},
+		processHtmlFile: boolean;
+	};
 	vitePress?: {
-		processMdFile: boolean,
-	},
+		processMdFile: boolean;
+	};
+	json?: {
+		customBlockSchemaUrls?: Record<string, string>;
+	};
 	/**
 	 * @example ['vue1', 'vue2']
 	 */
-	additionalExtensions?: string[],
+	additionalExtensions?: string[];
 };

--- a/vue-language-tools/vue-language-service/src/languageService.ts
+++ b/vue-language-tools/vue-language-service/src/languageService.ts
@@ -20,9 +20,14 @@ import useTwoslashQueries from './plugins/vue-twoslash-queries';
 import useVueTemplateLanguagePlugin from './plugins/vue-template';
 import type { Data } from '@volar-plugins/typescript/src/services/completions/basic';
 
+export interface Settings {
+	json?: Parameters<typeof useJsonPlugin>[0];
+}
+
 export function getLanguageServicePlugins(
 	host: vue.LanguageServiceHost,
 	apis: embeddedLS.LanguageService,
+	settings?: Settings,
 ): embeddedLS.LanguageServicePlugin[] {
 
 	// plugins
@@ -144,7 +149,7 @@ export function getLanguageServicePlugins(
 		getVueDocument: (document) => apis.context.documents.get(document.uri),
 	});
 	const cssPlugin = useCssPlugin();
-	const jsonPlugin = useJsonPlugin();
+	const jsonPlugin = useJsonPlugin(settings?.json);
 	const emmetPlugin = useEmmetPlugin();
 	const autoDotValuePlugin = useAutoDotValuePlugin();
 	const referencesCodeLensPlugin = useReferencesCodeLensPlugin({
@@ -219,6 +224,7 @@ export function createLanguageService(
 	host: LanguageServiceHost,
 	env: embeddedLS.LanguageServicePluginContext['env'],
 	documentRegistry?: ts.DocumentRegistry,
+	settings?: Settings,
 ) {
 
 	const vueLanguageModule = vue.createLanguageModule(
@@ -233,7 +239,7 @@ export function createLanguageService(
 		host,
 		context: core,
 		getPlugins() {
-			return getLanguageServicePlugins(host, languageService);
+			return getLanguageServicePlugins(host, languageService, settings);
 		},
 		documentRegistry,
 	});


### PR DESCRIPTION
Implement https://github.com/johnsoncodehk/volar-plugins/pull/17 in json plugin.

@kingyue737 we can add default urls config for `volar.vueserver.json.customBlockSchemaUrls`, please feel free to PR if you know some valid json schema links for custom blocks.