### PR TITLE
fix: Fix the inaccurate judgment of "vue.js"

### DIFF
--- a/packages/preview/bin/vite/config.ts
+++ b/packages/preview/bin/vite/config.ts
@@ -318,7 +318,7 @@ config.plugins.push({
 	name: '__volar_preview',
 	transform(this, code, id, options?) {
 		const createAppText = 'createApp,';
-		if (id.indexOf('vue.js?') >= 0 && code.indexOf(createAppText) >= 0 && code.indexOf('__createAppProxy') === -1) {
+		if (id.indexOf('/vue.js?') >= 0 && code.indexOf(createAppText) >= 0 && code.indexOf('__createAppProxy') === -1) {
 			const createAppOffset = code.lastIndexOf(createAppText);
 			code =
 				code.substring(0, createAppOffset)


### PR DESCRIPTION
It can't preview the webpage in the VSCode when the project is with ArcoVue(@arco-design/web-vue, a UI framework powered by ByteDance), because of the main JavaScript file of ArcoVue is "@arco-design_web-vue.js", the script will inject into this file too.