### PR TITLE
feat: add volar.virtualFiles.mappingSelectionBackgroundColor setting

### DIFF
--- a/extensions/vscode-vue-language-features/package.json
+++ b/extensions/vscode-vue-language-features/package.json
@@ -547,6 +547,15 @@
 					"type": "number",
 					"default": 200,
 					"description": "Delay time for diagnostics."
+				},
+				"volar.virtualFiles.mappingSelectionBackgroundColor": {
+					"type": [
+						"null",
+						"string",
+						"object"
+					],
+					"default": null,
+					"description": "Virtual files mapping selection background color."
 				}
 			}
 		},

--- a/extensions/vscode-vue-language-features/src/features/virtualFiles.ts
+++ b/extensions/vscode-vue-language-features/src/features/virtualFiles.ts
@@ -4,6 +4,7 @@ import { WriteVirtualFilesNotification, GetVirtualFileNamesRequest, GetVirtualFi
 import { SourceMapBase } from '@volar/source-map';
 
 const scheme = 'volar-virtual-file';
+const mappingSelectionBackgroundColor = vscode.workspace.getConfiguration('volar').get('virtualFiles.mappingSelectionBackgroundColor');
 const mappingDecorationType = vscode.window.createTextEditorDecorationType({
 	borderWidth: '1px',
 	borderStyle: 'solid',
@@ -20,8 +21,12 @@ const mappingDecorationType = vscode.window.createTextEditorDecorationType({
 });
 const mappingSelectionDecorationType = vscode.window.createTextEditorDecorationType({
 	cursor: 'crosshair',
-	// use a themable color. See package.json for the declaration and default values.
-	backgroundColor: 'darkblue'
+	light: {
+		backgroundColor: mappingSelectionBackgroundColor ?? 'lightblue'
+	},
+	dark: {
+	  backgroundColor: mappingSelectionBackgroundColor ?? 'darkblue'
+	}
 });
 
 export async function register(context: vscode.ExtensionContext, client: BaseLanguageClient) {

--- a/extensions/vscode-vue-language-features/src/features/virtualFiles.ts
+++ b/extensions/vscode-vue-language-features/src/features/virtualFiles.ts
@@ -25,7 +25,7 @@ const mappingSelectionDecorationType = vscode.window.createTextEditorDecorationT
 		backgroundColor: mappingSelectionBackgroundColor ?? 'lightblue'
 	},
 	dark: {
-	  backgroundColor: mappingSelectionBackgroundColor ?? 'darkblue'
+		backgroundColor: mappingSelectionBackgroundColor ?? 'darkblue'
 	}
 });
 


### PR DESCRIPTION
close #2147

## default
- dark
  ![ddark](https://user-images.githubusercontent.com/26325820/205514427-4df6985e-f965-4514-a468-ebd4646dd777.png)
- light
  ![dlight](https://user-images.githubusercontent.com/26325820/205514447-ef2ebd28-7ab9-4e57-8921-e96abeed6cdf.png)
## configured by string
```
"volar.virtualFiles.mappingSelectionBackgroundColor":  "#F8C9AB"
```
- light
![strlight](https://user-images.githubusercontent.com/26325820/205514911-7ad943f3-65f7-4f66-86c4-3592ab964909.png)

## configured by theme
```
// https://code.visualstudio.com/api/references/theme-color#editor-colors
"volar.virtualFiles.mappingSelectionBackgroundColor": {
  "id": "editor.selectionBackground"
},
```
- dark
![主题dark](https://user-images.githubusercontent.com/26325820/205515069-123c800d-7fbd-417b-aa1c-b8c31f7dbf58.png)

- light
![主题light](https://user-images.githubusercontent.com/26325820/205515080-511d92dd-d813-4c57-b196-153445993120.png)


