### PR TITLE
fix: vue language server not starting in vscode web

### DIFF
--- a/extensions/vscode-vue-language-features/src/browserClientMain.ts
+++ b/extensions/vscode-vue-language-features/src/browserClientMain.ts
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
 		const worker = new Worker(serverMain.toString());
 		const clientOptions: lsp.LanguageClientOptions = {
 			documentSelector: langs.map<lsp.DocumentFilter>(lang => ({ language: lang })),
-			initializationOptions: initOptions,
+			initializationOptions: JSON.parse(JSON.stringify(initOptions)),
 			progressOnInitialization: true,
 			middleware,
 		};

--- a/extensions/vscode-vue-language-features/src/common.ts
+++ b/extensions/vscode-vue-language-features/src/common.ts
@@ -282,7 +282,7 @@ function getInitializationOptions(
 			full: lsp.TextDocumentSyncKind.Full,
 			none: lsp.TextDocumentSyncKind.None,
 		}[textDocumentSync] : lsp.TextDocumentSyncKind.Incremental,
-		typescript: tsVersion.getCurrentTsdk(context),
+		typescript: typeof navigator === undefined? tsVersion.getCurrentTsdk(context): { tsdk: 'tsserver.web.js' },
 		petiteVue: {
 			processHtmlFile: processHtml(),
 		},


### PR DESCRIPTION
## Problem

Currently the vue language server does not start in vscode web even though web compatible server is available because of following reasons

* it tries to get tsserver path which is not supported
```
Uncaught (in promise) TypeError: ry.getCurrentTsdk is not a function
    at iy (client.js?target=web:62:12469)
    at eval (client.js?target=web:62:7509)
    at Generator.next (<anonymous>)
    at eval (client.js?target=web:62:6338)
    at new Promise (<anonymous>)
    at Br (client.js?target=web:62:6135)
    at sf (client.js?target=web:62:7313)
    at i (client.js?target=web:62:7145)
    at eval (client.js?target=web:62:6962)
    at Generator.next (<anonymous>)
    at eval (client.js?target=web:62:6338)
    at new Promise (<anonymous>)
    at Br (client.js?target=web:62:6135)
    at LP (client.js?target=web:62:6881)
    at KP (client.js?target=web:62:14346)
    at Function._callActivateOptional (extensionHostWorker.js:78:17695)
    at Function._callActivate (extensionHostWorker.js:78:17355)
    at eval (extensionHostWorker.js:78:15148)
    at m._activate (extensionHostWorker.js:72:8305)
    at m._waitForDepsThenActivate (extensionHostWorker.js:72:8247)
    at m._initialize (extensionHostWorker.js:72:7611)
```
* language client tries to send initOptions which cannot be serialised over postMessage

```
workbench.web.main.js:sourcemap:86 [Extension Host] Sending request failed.
E @ workbench.web.main.js:sourcemap:86
$logExtensionHostMessage @ workbench.web.main.js:sourcemap:1721
N @ workbench.web.main.js:sourcemap:1721
M @ workbench.web.main.js:sourcemap:1721
H @ workbench.web.main.js:sourcemap:1721
G @ workbench.web.main.js:sourcemap:1721
(anonymous) @ workbench.web.main.js:sourcemap:1721
invoke @ workbench.web.main.js:sourcemap:82
deliver @ workbench.web.main.js:sourcemap:82
fire @ workbench.web.main.js:sourcemap:82
P.onmessage @ workbench.web.main.js:sourcemap:1956

```

## Fixes

* added a check to ensure we don't try to get tsserver path in vscode web
* have serialised the initOptions that are sent to the language server


https://user-images.githubusercontent.com/15448192/206264548-35d72cd5-2c22-4979-b2d3-d8f41daf5cbc.mov

