### PR TITLE
fix(v-bind): allow duplicate keys via v-bind

### DIFF
--- a/vue-language-tools/vue-language-core/src/generators/template.ts
+++ b/vue-language-tools/vue-language-core/src/generators/template.ts
@@ -1098,9 +1098,9 @@ export function generate(
 				&& prop.exp?.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION
 			) {
 				if (format === 'jsx')
-					codeGen.push('{...');
+					codeGen.push('{__VLS_bound');
 				else
-					codeGen.push('...');
+					codeGen.push('__VLS_bound');
 				writeInterpolation(
 					prop.exp.content,
 					prop.exp.loc.start.offset,


### PR DESCRIPTION
This PR might fix https://github.com/johnsoncodehk/volar/issues/2166. It does fix the error that entries of `v-bind` collide with already bound attributes.

An example of where this is wanted would be a slot that v-binds a name property:

```vue
<slot name="the-slot-name" v-bind="{name: 'Some name'}"></slot>
```

I would not rule out that I missed something obvious, so feel free to just close this PR in favor of a better fix.