### PR TITLE
fix: auto complete ref value with '.value' not working

### DIFF
--- a/packages/vscode-language-client/src/features/autoInsertion.ts
+++ b/packages/vscode-language-client/src/features/autoInsertion.ts
@@ -62,7 +62,7 @@ export async function register(
 
 				const result = await client.sendRequest(AutoInsertRequest.type, params);
 
-				if (result !== undefined) {
+				if (result !== undefined && result !== null) {
 					if (typeof result === 'string') {
 						return result;
 					}


### PR DESCRIPTION
fixes #2199 