### PR TITLE
feat(vue-tsc): `experimentalTscProgramCallbacks`

### DIFF
--- a/vue-language-tools/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/vue-language-tools/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -107,8 +107,9 @@
 					},
 					"markdownDescription": "https://github.com/johnsoncodehk/volar/issues/1969"
 				},
-				"experimentalTscProgramCallback": {
-					"type": "string"
+				"experimentalTscProgramCallbacks": {
+					"type": "array",
+					"markdownDescription": "https://github.com/johnsoncodehk/volar/pull/2217"
 				}
 			}
 		}

--- a/vue-language-tools/vue-language-core/schemas/vue-tsconfig.schema.json
+++ b/vue-language-tools/vue-language-core/schemas/vue-tsconfig.schema.json
@@ -106,6 +106,9 @@
 						}
 					},
 					"markdownDescription": "https://github.com/johnsoncodehk/volar/issues/1969"
+				},
+				"experimentalTscProgramCallback": {
+					"type": "string"
 				}
 			}
 		}

--- a/vue-language-tools/vue-tsc/src/proxy.ts
+++ b/vue-language-tools/vue-tsc/src/proxy.ts
@@ -26,6 +26,9 @@ export function createProgramProxy(
 		const ctx = {
 			projectVersion: 0,
 			options: options,
+			get languageServiceHost() {
+				return vueLsHost;
+			},
 		};
 		const vueCompilerOptions = getVueCompilerOptions();
 		const scripts = new Map<string, {
@@ -116,6 +119,13 @@ export function createProgramProxy(
 	for (const rootName of options.rootNames) {
 		// register file watchers
 		options.host.getSourceFile(rootName, ts.ScriptTarget.ESNext);
+	}
+
+	const vueCompilerOptions = program.__vue.languageServiceHost.getVueCompilationSettings();
+	if (vueCompilerOptions.experimentalTscProgramCallback) {
+		const dir = program.__vue.languageServiceHost.getCurrentDirectory();
+		const cb = require(require.resolve(vueCompilerOptions.experimentalTscProgramCallback, { paths: [dir] }));
+		cb(program);
 	}
 
 	return program;

--- a/vue-language-tools/vue-tsc/src/proxy.ts
+++ b/vue-language-tools/vue-tsc/src/proxy.ts
@@ -25,7 +25,7 @@ export function createProgramProxy(
 
 		const ctx = {
 			projectVersion: 0,
-			options: options,
+			options,
 			get languageServiceHost() {
 				return vueLsHost;
 			},
@@ -122,10 +122,12 @@ export function createProgramProxy(
 	}
 
 	const vueCompilerOptions = program.__vue.languageServiceHost.getVueCompilationSettings();
-	if (vueCompilerOptions.experimentalTscProgramCallback) {
-		const dir = program.__vue.languageServiceHost.getCurrentDirectory();
-		const cb = require(require.resolve(vueCompilerOptions.experimentalTscProgramCallback, { paths: [dir] }));
-		cb(program);
+	if (vueCompilerOptions.experimentalTscProgramCallbacks) {
+		for (const cbPath of vueCompilerOptions.experimentalTscProgramCallbacks) {
+			const dir = program.__vue.languageServiceHost.getCurrentDirectory();
+			const cb = require(require.resolve(cbPath, { paths: [dir] }));
+			cb(program);
+		}
 	}
 
 	return program;


### PR DESCRIPTION
This PR support setting a TS Program callback script for `vue-tsc` in `vueCompilerOptions`.

## Purpose

The TS program can pass to 3rd tools like ESLint to use.

For ESLint, reusing TS Program can get better performance in CI/CD and some other benefits. (See #2204)

This is not a complete vue-tsc + ESLint solution, we may have a separate module for working with experimentalTscProgramCallbacks to support ESLint.

## Usage

- tsconfig.json

```json
{
	"vueCompilerOptions": {
		"experimentalTscProgramCallbacks": ["./vueTscProgramCallback.js"]
	}
}
```

- vueTscProgramCallback.js

```js
/**
 * @param {import('typescript').Program} program 
 */
module.exports = function (program) {
	const rawInputFiles = program.__vue.options.rootNames; // .ts and .vue files
	const rawTsFilesAndVirtualTsFiles = program.__vue.languageServiceHost.getScriptFileNames(); // .ts and .vue.ts files
	// Please note that the TS Program does not handle message range mapping from virtual .vue.ts files to .vue files.
};
```