### PR TITLE
perf(vue-component-meta): resolve schema on demand

### DIFF
--- a/vue-language-tools/vue-component-meta/src/index.ts
+++ b/vue-language-tools/vue-component-meta/src/index.ts
@@ -506,11 +506,13 @@ function createSchemaResolvers(
 	}
 
 	function resolveCallbackSchema(signature: ts.Signature): PropertyMetaSchema {
+		let schema: PropertyMetaSchema[] | undefined;
+
 		return {
 			kind: 'event',
 			type: typeChecker.signatureToString(signature),
 			get schema() {
-				return (this as any)._schema ??= signature.parameters.length > 0
+				return schema ??= signature.parameters.length > 0
 					? typeChecker
 						.getTypeArguments(typeChecker.getTypeOfSymbolAtLocation(signature.parameters[0], symbolNode) as ts.TypeReference)
 						.map(resolveSchema)

--- a/vue-language-tools/vue-component-meta/src/types.ts
+++ b/vue-language-tools/vue-component-meta/src/types.ts
@@ -56,6 +56,6 @@ export type MetaCheckerSchemaOptions = boolean | {
 export interface MetaCheckerOptions {
 	schema?: MetaCheckerSchemaOptions;
 	forceUseTs?: boolean;
-	printer?: import('typescript').PrinterOptions;
+	printer?: ts.PrinterOptions;
 	rawType?: boolean;
 }

--- a/vue-language-tools/vue-component-meta/src/types.ts
+++ b/vue-language-tools/vue-component-meta/src/types.ts
@@ -15,28 +15,28 @@ export interface PropertyMeta {
 	type: string;
 	rawType?: ts.Type;
 	tags: { name: string, text?: string; }[];
-	schema?: PropertyMetaSchema;
+	schema: PropertyMetaSchema;
 };
 export interface EventMeta {
 	name: string;
 	type: string;
 	rawType?: ts.Type;
 	signature: string;
-	schema?: PropertyMetaSchema[];
+	schema: PropertyMetaSchema[];
 }
 export interface SlotMeta {
 	name: string;
 	type: string;
 	rawType?: ts.Type;
 	description: string;
-	schema?: PropertyMetaSchema;
+	schema: PropertyMetaSchema;
 }
 export interface ExposeMeta {
 	name: string;
 	description: string;
 	type: string;
 	rawType?: ts.Type;
-	schema?: PropertyMetaSchema;
+	schema: PropertyMetaSchema;
 }
 
 export type PropertyMetaSchema = string


### PR DESCRIPTION
This PR makes schema resolve on demand when accessing schema, it maybe avoids some crash cases. And `schema: true` are not needed anymore due to on-demand resolve.

cc @stafyniaksacha, @antfu

---

Btw after reviewing the current implementation, I think that for more complex use cases, users should be advised to use rawType to resolve themselves.