### PR TITLE
feat: add unknown on props `class` in public props

### DIFF
--- a/packages/language-core/lib/codegen/script/scriptSetup.ts
+++ b/packages/language-core/lib/codegen/script/scriptSetup.ts
@@ -466,6 +466,10 @@ function* generateComponentProps(
 		yield `}${endOfLine}`;
 	}
 
+	yield `type OverrideClassToAny<T> = {
+    [P in keyof T]: P extends 'class' ? unknown : T[P];
+  };`;
+
 	yield `type __VLS_PublicProps = `;
 	if (scriptSetupRanges.defineSlots && options.vueCompilerOptions.jsxSlots) {
 		if (ctx.generatedPropsType) {
@@ -479,7 +483,7 @@ function* generateComponentProps(
 			yield ` & `;
 		}
 		ctx.generatedPropsType = true;
-		yield `__VLS_Props`;
+		yield `OverrideClassToAny<__VLS_Props>`;
 	}
 	if (scriptSetupRanges.defineModel.length) {
 		if (ctx.generatedPropsType) {


### PR DESCRIPTION
Hello 👋 

Trying to play around with `class` inheritance with components, I experimented something a bit un-documented from VueJS: even if a props `class` is defined, the `class` compilation (transformining an object with conditions to a string) will still happen.

Here is a simple reproduction: [Vue Playground](https://play.vuejs.org/#eNqFUslu2zAQ/ZUJL7YB20LRngTZ3RCg7aEN2hx5UaSRzIQiCZJyXAj69wzJSPYhy0EQZ3vvzTKwr8Zsjz2ynBWussJ4cOh7A7JU7Y4z7zjbcyU6o62H77oz0FjdwWKbBSOULubwABYbGJ8zUoirSivnoXMt7EJ86W2PK66KLPEROhkeOyNLj2QBFIcP+2GIJeNYZGRF713vvVaQV7J0LmgjIM7gSyVF9UD2cgW7PSwT0xX9VqT9Fp0vslSaYGITM8gAnjLyQLaGRaM13JV2kUMAXwPZObWVUoKLuhuJMyOoIptFszUNivpsRLu9d1rRNIfAxVlFZEKi/WO8oDlwRnAhEmKllPrxV/RFtslfHbB6eMF/707Bx9mNRYf2SM3PMV/aFn0KX//7jSd6z8FO172k7DeCf9Fp2QeNKe1br2qSfZEX1f6MixaqvXXXJ4/KTU3FXVDmGPM5o+WHOb/W+lnux+2nWMfVSFOcbuqdc0wnZaw2jlZdYyMU3gSriAxxt59zcN6SVELeL985uFoc44OeV5sN/ECL4A+YkEA4UDrxlS3V1LDZTOlUeT6mqGgbragzZLwKGU6jD2Clok8+lv8dlM+azwQAw3ABO9KgImY2SZ5eF+fIFRufAG9SRYU=).

This behavior is quite interesting as it allows the child component to get the class without having the need to use `defineOptions({ inheritAttrs: false })` and `useAttrs`. The typing on the `class` is therefore better, even if the user can in theory put any kind of type like `boolean` for the `class` props, not resulting in a type error, even if the `class` will be a string after VueJS compilation.

I would like to propose a change in the typing tools in this repository to allow this behavior from a typing perspective. The `vue-tsc` and language server are raising errors about the type of the `class` props being given to the child component, even if VueJS **will always compile this props to a string**.

I'm trying to put the default type of `class` from VueJS which is `unknown`: https://github.com/vuejs/core/blob/e60edc06f29b32c8f3a44d0ab3558a0569515e8f/packages/runtime-core/src/component.ts#L185, but only on the public interface of a component, as it will be a `string` inside.

I think enforcing the prop `class` to always be a string inside the component in itself needs to be done in the VueJS `core` repository, but I'm not sure.

This is clearly a proposal, happy to discuss this but I find the behavior quite useful and would like to push more usage of this in the VueJS community.

