### PR TITLE
refactor(language-server): parsing interpolations in extension client

### DIFF
--- a/extensions/vscode/index.ts
+++ b/extensions/vscode/index.ts
@@ -16,6 +16,7 @@ import {
 } from 'reactive-vscode';
 import * as vscode from 'vscode';
 import { config } from './lib/config';
+import * as interpolationDecorators from './lib/interpolationDecorators';
 import * as reactivityVisualization from './lib/reactivityVisualization';
 import * as welcome from './lib/welcome';
 
@@ -100,6 +101,7 @@ export = defineExtension(() => {
 		activateAutoInsertion(selectors, client);
 		activateDocumentDropEdit(selectors, client);
 
+		interpolationDecorators.activate(context, selectors, client);
 		reactivityVisualization.activate(context, selectors);
 		welcome.activate(context);
 	}, { immediate: true });

--- a/extensions/vscode/lib/interpolationDecorators.ts
+++ b/extensions/vscode/lib/interpolationDecorators.ts
@@ -1,0 +1,68 @@
+import type { BaseLanguageClient } from '@volar/vscode';
+import * as vscode from 'vscode';
+import { config } from './config';
+
+const decorationType = vscode.window.createTextEditorDecorationType({
+	borderWidth: '1px',
+	borderStyle: 'solid',
+	borderColor: 'rgba(128, 128, 128, 0.5)',
+	backgroundColor: 'rgba(200, 200, 200, 0.1)',
+	borderRadius: '4px',
+});
+
+export async function activate(
+	context: vscode.ExtensionContext,
+	selector: vscode.DocumentSelector,
+	client: BaseLanguageClient,
+) {
+	await client.start();
+
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+
+	for (const editor of vscode.window.visibleTextEditors) {
+		updateDecorations(editor);
+	}
+
+	context.subscriptions.push(
+		vscode.window.onDidChangeActiveTextEditor(editor => {
+			if (editor) {
+				updateDecorations(editor);
+			}
+		}),
+		vscode.workspace.onDidChangeTextDocument(() => {
+			const editor = vscode.window.activeTextEditor;
+			if (editor) {
+				clearTimeout(timeout);
+				timeout = setTimeout(() => updateDecorations(editor), 100);
+			}
+		}),
+		vscode.workspace.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('vue.editor.templateInterpolationDecorators')) {
+				for (const editor of vscode.window.visibleTextEditors) {
+					updateDecorations(editor);
+				}
+			}
+		}),
+	);
+
+	function updateDecorations(editor: vscode.TextEditor) {
+		if (!vscode.languages.match(selector, editor.document)) {
+			return;
+		}
+		if (!config.editor.templateInterpolationDecorators) {
+			editor.setDecorations(decorationType, []);
+			return;
+		}
+		editor.setDecorations(
+			decorationType,
+			[...editor.document.getText().matchAll(/{{[\s\S]*?}}/g)].map(match => {
+				const start = match.index + 2;
+				const end = match.index + match[0].length - 2;
+				return new vscode.Range(
+					editor.document.positionAt(start),
+					editor.document.positionAt(end),
+				);
+			}),
+		);
+	}
+}


### PR DESCRIPTION
Removed the `vue/interpolationRanges` request handling in the language server, and instead used simple regex parsing for interpolations in the extension client.