### PR TITLE
fix(typescript-plugin): place `__vue__` in project instead of program

### DIFF
--- a/extensions/vscode/reactivityAnalysis/plugin.ts
+++ b/extensions/vscode/reactivityAnalysis/plugin.ts
@@ -45,7 +45,7 @@ function getReactivityAnalysis(
 		project: ts.server.Project;
 	};
 
-	const language: Language<string> | undefined = project['program']?.__vue__?.language;
+	const language: Language<string> | undefined = (project as any).__vue__?.language;
 	if (!language) {
 		return;
 	}


### PR DESCRIPTION
Since `info.project.program` is rebuilt with each code change, the reactivity analysis plugin loses access to `__vue__`.

Which can be resolved by hoisting `__vue__` to `info.project`.