### PR TITLE
fix(language-core): handle `@vue-expect-error` in `v-else` template branch

### DIFF
--- a/test-workspace/tsc/passedFixtures/#5751/tsconfig.json
+++ b/test-workspace/tsc/passedFixtures/#5751/tsconfig.json
@@ -1,4 +1,0 @@
-{
-	"extends": "../../../tsconfig.base.json",
-	"include": ["**/*"]
-}

--- a/test-workspace/tsc/passedFixtures/vue3/#5751/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#5751/main.vue
@@ -2,6 +2,6 @@
     <div v-if="false"></div>
     <template v-else>
         <!-- @vue-expect-error -->
-        <div :class="unknownProp"> Test </div>
+        <div :class="unknownProp"></div>
     </template>
 </template>

--- a/test-workspace/tsc/tsconfig.json
+++ b/test-workspace/tsc/tsconfig.json
@@ -18,7 +18,6 @@
 		{ "path": "./passedFixtures/#5111" },
 		{ "path": "./passedFixtures/#5136" },
 		{ "path": "./passedFixtures/#5338" },
-		{ "path": "./passedFixtures/#5751" },
 		{ "path": "./passedFixtures/core#9923" },
 		{ "path": "./passedFixtures/fallthroughAttributes" },
 		{ "path": "./passedFixtures/fallthroughAttributes_strictTemplate" },


### PR DESCRIPTION
Fixed #5751

<img width="429" height="190" alt="image" src="https://github.com/user-attachments/assets/c177d45c-26a2-4bdf-8307-0d9772016495" />
