### PR TITLE
perf(language-core): skip unnecessary runtime codegen step

### DIFF
--- a/packages/language-core/lib/plugins/vue-template-html.ts
+++ b/packages/language-core/lib/plugins/vue-template-html.ts
@@ -31,8 +31,7 @@ const plugin: VueLanguagePlugin = ({ modules }) => {
 					addedSuffix = true;
 				}
 
-				const ast = compiler.baseParse(template, {
-					...compiler.parserOptions,
+				const ast = compiler.parse(template, {
 					...options,
 					comments: true,
 				});


### PR DESCRIPTION
The generate step in `CompilerDOM.compile()` is redundant for language tools.