### PR TITLE
fix(vscode): make `vue.server.path` compatible with Windows

### DIFF
--- a/extensions/vscode/index.ts
+++ b/extensions/vscode/index.ts
@@ -207,7 +207,7 @@ function resolveServerPath() {
 	if (path.isAbsolute(config.server.path)) {
 		const entryFile = require.resolve('./index.js', { paths: [config.server.path] });
 		const tsPluginPath = require.resolve('@vue/typescript-plugin', { paths: [path.dirname(entryFile)] });
-		fs.writeFileSync(tsPluginPackPath, `module.exports = require("${tsPluginPath}");`);
+		fs.writeFileSync(tsPluginPackPath, `module.exports = require(${JSON.stringify(tsPluginPath)});`);
 		return entryFile;
 	}
 
@@ -219,7 +219,7 @@ function resolveServerPath() {
 			const serverPath = path.join(uri.fsPath, config.server.path);
 			const entryFile = require.resolve('./index.js', { paths: [serverPath] });
 			const tsPluginPath = require.resolve('@vue/typescript-plugin', { paths: [path.dirname(entryFile)] });
-			fs.writeFileSync(tsPluginPackPath, `module.exports = require("${tsPluginPath}");`);
+			fs.writeFileSync(tsPluginPackPath, `module.exports = require(${JSON.stringify(tsPluginPath)});`);
 			return entryFile;
 		}
 		catch {}


### PR DESCRIPTION
fix #5738, fix #5720