### PR TITLE
fix(language-core): ensure `<script>` content generates before `<script setup>`

### DIFF
--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -56,13 +56,17 @@ function* generateWorker(
 
 	// <script> + <script setup>
 	if (script && scriptRanges && scriptSetup && scriptSetupRanges) {
-		// <script> head
+		// <script>
 		const { exportDefault, componentOptions } = scriptRanges;
 		if (exportDefault) {
-			yield* generateSfcBlockSection(script, 0, exportDefault.start, codeFeatures.all, true);
+			const { expression: options } = componentOptions ?? exportDefault;
+			yield* generateSfcBlockSection(script, 0, options.start, codeFeatures.all);
+			yield exportExpression;
+			yield* generateSfcBlockSection(script, options.end, script.content.length, codeFeatures.all, true);
 		}
 		else {
 			yield* generateSfcBlockSection(script, 0, script.content.length, codeFeatures.all, true);
+			yield `export default ${exportExpression}${endOfLine}`;
 		}
 
 		// <script setup>
@@ -94,17 +98,6 @@ function* generateWorker(
 				[`return `],
 			);
 			yield `})()${endOfLine}`;
-		}
-
-		// <script> tail
-		if (exportDefault) {
-			const { expression } = componentOptions ?? exportDefault;
-			yield* generateSfcBlockSection(script, exportDefault.start, expression.start, codeFeatures.all);
-			yield exportExpression;
-			yield* generateSfcBlockSection(script, expression.end, script.content.length, codeFeatures.all);
-		}
-		else {
-			yield `export default ${exportExpression}${endOfLine}`;
 		}
 	}
 	// only <script setup>

--- a/test-workspace/tsc/passedFixtures/vue3/#5776/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/#5776/main.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+defineProps<{ msg: string }>();
+
+const count = ref(eee);
+</script>
+
+<script lang="ts">
+export default {
+	name: '1212'
+}
+export const eee = 1
+</script>
+
+<template>
+	<div class="flex items-center justify-center w-screen h-screen">
+		{{ count }}
+	</div>
+</template>

--- a/test-workspace/tsc/passedFixtures/vue3/script-setup-scope/export-order.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/script-setup-scope/export-order.vue
@@ -10,6 +10,5 @@ export const useTwo = async () => ({ two: 'two' })
 
 <script lang="ts" setup>
 useOne()
-// @ts-expect-error
 useTwo()
 </script>


### PR DESCRIPTION
Fix #5776