### PR TITLE
refactor(component-meta): deprecated `rawType` and `__internal__.tsLs`

### DIFF
--- a/packages/component-meta/lib/types.ts
+++ b/packages/component-meta/lib/types.ts
@@ -30,39 +30,55 @@ export interface PropertyMeta {
 	global: boolean;
 	required: boolean;
 	type: string;
-	rawType?: ts.Type;
 	tags: { name: string; text?: string }[];
 	declarations: Declaration[];
 	schema: PropertyMetaSchema;
+	/**
+	 * @deprecated use `getTypeObject()` instead
+	 */
+	rawType?: ts.Type;
+	getTypeObject(): ts.Type;
 }
 
 export interface EventMeta {
 	name: string;
 	description: string;
 	type: string;
-	rawType?: ts.Type;
 	signature: string;
 	tags: { name: string; text?: string }[];
 	declarations: Declaration[];
 	schema: PropertyMetaSchema[];
+	/**
+	 * @deprecated use `getTypeObject()` instead
+	 */
+	rawType?: ts.Type;
+	getTypeObject(): ts.Type | undefined;
 }
 
 export interface SlotMeta {
 	name: string;
 	type: string;
-	rawType?: ts.Type;
 	description: string;
 	declarations: Declaration[];
 	schema: PropertyMetaSchema;
+	/**
+	 * @deprecated use `getTypeObject()` instead
+	 */
+	rawType?: ts.Type;
+	getTypeObject(): ts.Type;
 }
 
 export interface ExposeMeta {
 	name: string;
 	description: string;
 	type: string;
-	rawType?: ts.Type;
 	declarations: Declaration[];
 	schema: PropertyMetaSchema;
+	/**
+	 * @deprecated use `getTypeObject()` instead
+	 */
+	rawType?: ts.Type;
+	getTypeObject(): ts.Type;
 }
 
 export type PropertyMetaSchema =
@@ -85,6 +101,9 @@ export interface MetaCheckerOptions {
 	schema?: MetaCheckerSchemaOptions;
 	forceUseTs?: boolean;
 	printer?: ts.PrinterOptions;
-	rawType?: boolean;
 	noDeclarations?: boolean;
+	/**
+	 * @deprecated No longer needed, use `getTypeObject()` instead
+	 */
+	rawType?: boolean;
 }

--- a/packages/component-meta/tests/index.spec.ts
+++ b/packages/component-meta/tests/index.spec.ts
@@ -35,46 +35,48 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 			const onUpdateModelValue = meta.events.find(event => event.name === 'update:modelValue');
 
 			expect(modelValue).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": undefined,
-			  "description": "required number modelValue",
-			  "global": false,
-			  "name": "modelValue",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": "number",
-			  "tags": [],
-			  "type": "number",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": undefined,
+				  "description": "required number modelValue",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "modelValue",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": "number",
+				  "tags": [],
+				  "type": "number",
+				}
+			`);
 			expect(onUpdateModelValue).toBeDefined();
 
 			const foo = meta.props.find(prop => prop.name === 'foo');
 			const onUpdateFoo = meta.events.find(event => event.name === 'update:foo');
 
 			expect(foo).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": "false",
-			  "description": "optional boolean foo with default false",
-			  "global": false,
-			  "name": "foo",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "false",
-			      "true",
-			    ],
-			    "type": "boolean | undefined",
-			  },
-			  "tags": [],
-			  "type": "boolean | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": "false",
+				  "description": "optional boolean foo with default false",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "foo",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "false",
+				      "true",
+				    ],
+				    "type": "boolean | undefined",
+				  },
+				  "tags": [],
+				  "type": "boolean | undefined",
+				}
+			`);
 			expect(onUpdateFoo).toBeDefined();
 
 			const bar = meta.props.find(prop => prop.name === 'bar');
@@ -82,45 +84,47 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 			const onUpdateBaz = meta.events.find(event => event.name === 'update:bar');
 
 			expect(bar).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "optional string bar with lazy and trim modifiers",
-			  "global": false,
-			  "name": "bar",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "optional string bar with lazy and trim modifiers",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "bar",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 			expect(barModifiers).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "barModifiers",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "Partial<Record<"trim" | "lazy", true>>",
-			    ],
-			    "type": "Partial<Record<"trim" | "lazy", true>> | undefined",
-			  },
-			  "tags": [],
-			  "type": "Partial<Record<"trim" | "lazy", true>> | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "barModifiers",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "Partial<Record<"trim" | "lazy", true>>",
+				    ],
+				    "type": "Partial<Record<"trim" | "lazy", true>> | undefined",
+				  },
+				  "tags": [],
+				  "type": "Partial<Record<"trim" | "lazy", true>> | undefined",
+				}
+			`);
 			expect(onUpdateBaz).toBeDefined();
 		});
 
@@ -135,459 +139,482 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 
 			const foo = meta.props.find(prop => prop.name === 'foo');
 			expect(foo).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "string foo",
-			  "global": false,
-			  "name": "foo",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": "string",
-			  "tags": [
-			    {
-			      "name": "default",
-			      "text": ""rounded"",
-			    },
-			    {
-			      "name": "since",
-			      "text": "v1.0.0",
-			    },
-			    {
-			      "name": "see",
-			      "text": "https://vuejs.org/",
-			    },
-			    {
-			      "name": "example",
-			      "text": "\`\`\`vue
-			<template>
-			  <component foo="straight" />
-			</template>
-			\`\`\`",
-			    },
-			  ],
-			  "type": "string",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "string foo",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "foo",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": "string",
+				  "tags": [
+				    {
+				      "name": "default",
+				      "text": ""rounded"",
+				    },
+				    {
+				      "name": "since",
+				      "text": "v1.0.0",
+				    },
+				    {
+				      "name": "see",
+				      "text": "https://vuejs.org/",
+				    },
+				    {
+				      "name": "example",
+				      "text": "\`\`\`vue
+				<template>
+				  <component foo="straight" />
+				</template>
+				\`\`\`",
+				    },
+				  ],
+				  "type": "string",
+				}
+			`);
 
 			const bar = meta.props.find(prop => prop.name === 'bar');
 			expect(bar).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": "1",
-			  "description": "optional number bar",
-			  "global": false,
-			  "name": "bar",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "number",
-			    ],
-			    "type": "number | undefined",
-			  },
-			  "tags": [],
-			  "type": "number | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": "1",
+				  "description": "optional number bar",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "bar",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "number",
+				    ],
+				    "type": "number | undefined",
+				  },
+				  "tags": [],
+				  "type": "number | undefined",
+				}
+			`);
 
 			const baz = meta.props.find(prop => prop.name === 'baz');
 			expect(baz).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": "["foo", "bar"]",
-			  "description": "string array baz",
-			  "global": false,
-			  "name": "baz",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      {
-			        "kind": "array",
-			        "schema": [
-			          "string",
-			        ],
-			        "type": "string[]",
-			      },
-			    ],
-			    "type": "string[] | undefined",
-			  },
-			  "tags": [],
-			  "type": "string[] | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": "["foo", "bar"]",
+				  "description": "string array baz",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "baz",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      {
+				        "kind": "array",
+				        "schema": [
+				          "string",
+				        ],
+				        "type": "string[]",
+				      },
+				    ],
+				    "type": "string[] | undefined",
+				  },
+				  "tags": [],
+				  "type": "string[] | undefined",
+				}
+			`);
 
 			const union = meta.props.find(prop => prop.name === 'union');
 			expect(union).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "required union type",
-			  "global": false,
-			  "name": "union",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "string",
-			      "number",
-			    ],
-			    "type": "string | number",
-			  },
-			  "tags": [],
-			  "type": "string | number",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "required union type",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "union",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "string",
+				      "number",
+				    ],
+				    "type": "string | number",
+				  },
+				  "tags": [],
+				  "type": "string | number",
+				}
+			`);
 
 			const unionOptional = meta.props.find(prop => prop.name === 'unionOptional');
 			expect(unionOptional).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "optional union type",
-			  "global": false,
-			  "name": "unionOptional",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			      "number",
-			    ],
-			    "type": "string | number | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | number | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "optional union type",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "unionOptional",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				      "number",
+				    ],
+				    "type": "string | number | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | number | undefined",
+				}
+			`);
 
 			const nested = meta.props.find(prop => prop.name === 'nested');
 			expect(nested).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "required nested object",
-			  "global": false,
-			  "name": "nested",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "object",
-			    "schema": {
-			      "nestedProp": {
-			        "declarations": [],
-			        "description": "nested prop documentation",
-			        "global": false,
-			        "name": "nestedProp",
-			        "rawType": undefined,
-			        "required": true,
-			        "schema": "string",
-			        "tags": [],
-			        "type": "string",
-			      },
-			    },
-			    "type": "MyNestedProps",
-			  },
-			  "tags": [],
-			  "type": "MyNestedProps",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "required nested object",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "nested",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "object",
+				    "schema": {
+				      "nestedProp": {
+				        "declarations": [],
+				        "description": "nested prop documentation",
+				        "getTypeObject": [Function],
+				        "global": false,
+				        "name": "nestedProp",
+				        "rawType": undefined,
+				        "required": true,
+				        "schema": "string",
+				        "tags": [],
+				        "type": "string",
+				      },
+				    },
+				    "type": "MyNestedProps",
+				  },
+				  "tags": [],
+				  "type": "MyNestedProps",
+				}
+			`);
 
 			const nestedIntersection = meta.props.find(prop => prop.name === 'nestedIntersection');
 			expect(nestedIntersection).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "required nested object with intersection",
-			  "global": false,
-			  "name": "nestedIntersection",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "object",
-			    "schema": {
-			      "additionalProp": {
-			        "declarations": [],
-			        "description": "required additional property",
-			        "global": false,
-			        "name": "additionalProp",
-			        "rawType": undefined,
-			        "required": true,
-			        "schema": "string",
-			        "tags": [],
-			        "type": "string",
-			      },
-			      "nestedProp": {
-			        "declarations": [],
-			        "description": "nested prop documentation",
-			        "global": false,
-			        "name": "nestedProp",
-			        "rawType": undefined,
-			        "required": true,
-			        "schema": "string",
-			        "tags": [],
-			        "type": "string",
-			      },
-			    },
-			    "type": "MyNestedProps & { additionalProp: string; }",
-			  },
-			  "tags": [],
-			  "type": "MyNestedProps & { additionalProp: string; }",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "required nested object with intersection",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "nestedIntersection",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "object",
+				    "schema": {
+				      "additionalProp": {
+				        "declarations": [],
+				        "description": "required additional property",
+				        "getTypeObject": [Function],
+				        "global": false,
+				        "name": "additionalProp",
+				        "rawType": undefined,
+				        "required": true,
+				        "schema": "string",
+				        "tags": [],
+				        "type": "string",
+				      },
+				      "nestedProp": {
+				        "declarations": [],
+				        "description": "nested prop documentation",
+				        "getTypeObject": [Function],
+				        "global": false,
+				        "name": "nestedProp",
+				        "rawType": undefined,
+				        "required": true,
+				        "schema": "string",
+				        "tags": [],
+				        "type": "string",
+				      },
+				    },
+				    "type": "MyNestedProps & { additionalProp: string; }",
+				  },
+				  "tags": [],
+				  "type": "MyNestedProps & { additionalProp: string; }",
+				}
+			`);
 
 			const nestedOptional = meta.props.find(prop => prop.name === 'nestedOptional');
 			expect(nestedOptional).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "optional nested object",
-			  "global": false,
-			  "name": "nestedOptional",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      {
-			        "kind": "object",
-			        "schema": {
-			          "nestedProp": {
-			            "declarations": [],
-			            "description": "nested prop documentation",
-			            "global": false,
-			            "name": "nestedProp",
-			            "rawType": undefined,
-			            "required": true,
-			            "schema": "string",
-			            "tags": [],
-			            "type": "string",
-			          },
-			        },
-			        "type": "MyNestedProps",
-			      },
-			      "MyIgnoredNestedProps",
-			    ],
-			    "type": "MyNestedProps | MyIgnoredNestedProps | undefined",
-			  },
-			  "tags": [],
-			  "type": "MyNestedProps | MyIgnoredNestedProps | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "optional nested object",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "nestedOptional",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      {
+				        "kind": "object",
+				        "schema": {
+				          "nestedProp": {
+				            "declarations": [],
+				            "description": "nested prop documentation",
+				            "getTypeObject": [Function],
+				            "global": false,
+				            "name": "nestedProp",
+				            "rawType": undefined,
+				            "required": true,
+				            "schema": "string",
+				            "tags": [],
+				            "type": "string",
+				          },
+				        },
+				        "type": "MyNestedProps",
+				      },
+				      "MyIgnoredNestedProps",
+				    ],
+				    "type": "MyNestedProps | MyIgnoredNestedProps | undefined",
+				  },
+				  "tags": [],
+				  "type": "MyNestedProps | MyIgnoredNestedProps | undefined",
+				}
+			`);
 
 			const array = meta.props.find(prop => prop.name === 'array');
 			expect(array).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "required array object",
-			  "global": false,
-			  "name": "array",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "array",
-			    "schema": [
-			      {
-			        "kind": "object",
-			        "schema": {
-			          "nestedProp": {
-			            "declarations": [],
-			            "description": "nested prop documentation",
-			            "global": false,
-			            "name": "nestedProp",
-			            "rawType": undefined,
-			            "required": true,
-			            "schema": "string",
-			            "tags": [],
-			            "type": "string",
-			          },
-			        },
-			        "type": "MyNestedProps",
-			      },
-			    ],
-			    "type": "MyNestedProps[]",
-			  },
-			  "tags": [],
-			  "type": "MyNestedProps[]",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "required array object",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "array",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "array",
+				    "schema": [
+				      {
+				        "kind": "object",
+				        "schema": {
+				          "nestedProp": {
+				            "declarations": [],
+				            "description": "nested prop documentation",
+				            "getTypeObject": [Function],
+				            "global": false,
+				            "name": "nestedProp",
+				            "rawType": undefined,
+				            "required": true,
+				            "schema": "string",
+				            "tags": [],
+				            "type": "string",
+				          },
+				        },
+				        "type": "MyNestedProps",
+				      },
+				    ],
+				    "type": "MyNestedProps[]",
+				  },
+				  "tags": [],
+				  "type": "MyNestedProps[]",
+				}
+			`);
 
 			const arrayOptional = meta.props.find(prop => prop.name === 'arrayOptional');
 			expect(arrayOptional).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "optional array object",
-			  "global": false,
-			  "name": "arrayOptional",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      {
-			        "kind": "array",
-			        "schema": [
-			          {
-			            "kind": "object",
-			            "schema": {
-			              "nestedProp": {
-			                "declarations": [],
-			                "description": "nested prop documentation",
-			                "global": false,
-			                "name": "nestedProp",
-			                "rawType": undefined,
-			                "required": true,
-			                "schema": "string",
-			                "tags": [],
-			                "type": "string",
-			              },
-			            },
-			            "type": "MyNestedProps",
-			          },
-			        ],
-			        "type": "MyNestedProps[]",
-			      },
-			    ],
-			    "type": "MyNestedProps[] | undefined",
-			  },
-			  "tags": [],
-			  "type": "MyNestedProps[] | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "optional array object",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "arrayOptional",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      {
+				        "kind": "array",
+				        "schema": [
+				          {
+				            "kind": "object",
+				            "schema": {
+				              "nestedProp": {
+				                "declarations": [],
+				                "description": "nested prop documentation",
+				                "getTypeObject": [Function],
+				                "global": false,
+				                "name": "nestedProp",
+				                "rawType": undefined,
+				                "required": true,
+				                "schema": "string",
+				                "tags": [],
+				                "type": "string",
+				              },
+				            },
+				            "type": "MyNestedProps",
+				          },
+				        ],
+				        "type": "MyNestedProps[]",
+				      },
+				    ],
+				    "type": "MyNestedProps[] | undefined",
+				  },
+				  "tags": [],
+				  "type": "MyNestedProps[] | undefined",
+				}
+			`);
 
 			const enumValue = meta.props.find(prop => prop.name === 'enumValue');
 			expect(enumValue).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "enum value",
-			  "global": false,
-			  "name": "enumValue",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "MyEnum.Small",
-			      "MyEnum.Medium",
-			      "MyEnum.Large",
-			    ],
-			    "type": "MyEnum",
-			  },
-			  "tags": [],
-			  "type": "MyEnum",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "enum value",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "enumValue",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "MyEnum.Small",
+				      "MyEnum.Medium",
+				      "MyEnum.Large",
+				    ],
+				    "type": "MyEnum",
+				  },
+				  "tags": [],
+				  "type": "MyEnum",
+				}
+			`);
 
 			const namespaceType = meta.props.find(prop => prop.name === 'namespaceType');
 			expect(namespaceType).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "namespace type",
-			  "global": false,
-			  "name": "namespaceType",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "object",
-			    "schema": {},
-			    "type": "MyNamespace.MyType",
-			  },
-			  "tags": [],
-			  "type": "MyNamespace.MyType",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "namespace type",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "namespaceType",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "object",
+				    "schema": {},
+				    "type": "MyNamespace.MyType",
+				  },
+				  "tags": [],
+				  "type": "MyNamespace.MyType",
+				}
+			`);
 
 			const literalFromContext = meta.props.find(prop => prop.name === 'literalFromContext');
 			expect(literalFromContext).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "literal type alias that require context",
-			  "global": false,
-			  "name": "literalFromContext",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      ""Uncategorized"",
-			      ""Content"",
-			      ""Interaction"",
-			      ""Display"",
-			      ""Forms"",
-			      ""Addons"",
-			    ],
-			    "type": ""Uncategorized" | "Content" | "Interaction" | "Display" | "Forms" | "Addons"",
-			  },
-			  "tags": [],
-			  "type": ""Uncategorized" | "Content" | "Interaction" | "Display" | "Forms" | "Addons"",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "literal type alias that require context",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "literalFromContext",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      ""Uncategorized"",
+				      ""Content"",
+				      ""Interaction"",
+				      ""Display"",
+				      ""Forms"",
+				      ""Addons"",
+				    ],
+				    "type": ""Uncategorized" | "Content" | "Interaction" | "Display" | "Forms" | "Addons"",
+				  },
+				  "tags": [],
+				  "type": ""Uncategorized" | "Content" | "Interaction" | "Display" | "Forms" | "Addons"",
+				}
+			`);
 
 			const inlined = meta.props.find(prop => prop.name === 'inlined');
 			expect(inlined).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "inlined",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "object",
-			    "schema": {
-			      "foo": {
-			        "declarations": [],
-			        "description": "",
-			        "global": false,
-			        "name": "foo",
-			        "rawType": undefined,
-			        "required": true,
-			        "schema": "string",
-			        "tags": [],
-			        "type": "string",
-			      },
-			    },
-			    "type": "{ foo: string; }",
-			  },
-			  "tags": [],
-			  "type": "{ foo: string; }",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "inlined",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "object",
+				    "schema": {
+				      "foo": {
+				        "declarations": [],
+				        "description": "",
+				        "getTypeObject": [Function],
+				        "global": false,
+				        "name": "foo",
+				        "rawType": undefined,
+				        "required": true,
+				        "schema": "string",
+				        "tags": [],
+				        "type": "string",
+				      },
+				    },
+				    "type": "{ foo: string; }",
+				  },
+				  "tags": [],
+				  "type": "{ foo: string; }",
+				}
+			`);
 
 			const recursive = meta.props.find(prop => prop.name === 'recursive');
 			expect(recursive).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "recursive",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": {
-			    "kind": "object",
-			    "schema": {
-			      "recursive": {
-			        "declarations": [],
-			        "description": "",
-			        "global": false,
-			        "name": "recursive",
-			        "rawType": undefined,
-			        "required": true,
-			        "schema": "MyNestedRecursiveProps",
-			        "tags": [],
-			        "type": "MyNestedRecursiveProps",
-			      },
-			    },
-			    "type": "MyNestedRecursiveProps",
-			  },
-			  "tags": [],
-			  "type": "MyNestedRecursiveProps",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "recursive",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": {
+				    "kind": "object",
+				    "schema": {
+				      "recursive": {
+				        "declarations": [],
+				        "description": "",
+				        "getTypeObject": [Function],
+				        "global": false,
+				        "name": "recursive",
+				        "rawType": undefined,
+				        "required": true,
+				        "schema": "MyNestedRecursiveProps",
+				        "tags": [],
+				        "type": "MyNestedRecursiveProps",
+				      },
+				    },
+				    "type": "MyNestedRecursiveProps",
+				  },
+				  "tags": [],
+				  "type": "MyNestedRecursiveProps",
+				}
+			`);
 		});
 
 		test('reference-type-props-destructured', () => {
@@ -615,124 +642,130 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 
 			const foo = meta.props.find(prop => prop.name === 'foo');
 			expect(foo).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": undefined,
-			  "description": "",
-			  "global": false,
-			  "name": "foo",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": "string",
-			  "tags": [],
-			  "type": "string",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": undefined,
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "foo",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": "string",
+				  "tags": [],
+				  "type": "string",
+				}
+			`);
 
 			const bar = meta.props.find(prop => prop.name === 'bar');
 			expect(bar).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": ""BAR"",
-			  "description": "",
-			  "global": false,
-			  "name": "bar",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": ""BAR"",
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "bar",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 
 			const baz = meta.props.find(prop => prop.name === 'baz');
 			expect(baz).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": undefined,
-			  "description": "",
-			  "global": false,
-			  "name": "baz",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": undefined,
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "baz",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 
 			const xfoo = meta.props.find(prop => prop.name === 'xfoo');
 			expect(xfoo).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "xfoo",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": "string",
-			  "tags": [],
-			  "type": "string",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "xfoo",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": "string",
+				  "tags": [],
+				  "type": "string",
+				}
+			`);
 
 			const xbar = meta.props.find(prop => prop.name === 'xbar');
 			expect(xbar).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "xbar",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "xbar",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 
 			const xbaz = meta.props.find(prop => prop.name === 'xbaz');
 			expect(xbaz).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "xbaz",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "xbaz",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 		});
 
 		test('reference-type-props-js-setup', () => {
@@ -746,205 +779,214 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 
 			const foo = meta.props.find(prop => prop.name === 'foo');
 			expect(foo).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": undefined,
-			  "description": "",
-			  "global": false,
-			  "name": "foo",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": "string",
-			  "tags": [],
-			  "type": "string",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": undefined,
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "foo",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": "string",
+				  "tags": [],
+				  "type": "string",
+				}
+			`);
 
 			const bar = meta.props.find(prop => prop.name === 'bar');
 			expect(bar).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": ""BAR"",
-			  "description": "",
-			  "global": false,
-			  "name": "bar",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": ""BAR"",
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "bar",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 
 			const baz = meta.props.find(prop => prop.name === 'baz');
 			expect(baz).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": undefined,
-			  "description": "",
-			  "global": false,
-			  "name": "baz",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": undefined,
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "baz",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 
 			const xfoo = meta.props.find(prop => prop.name === 'xfoo');
 			expect(xfoo).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "xfoo",
-			  "rawType": undefined,
-			  "required": true,
-			  "schema": "string",
-			  "tags": [],
-			  "type": "string",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "xfoo",
+				  "rawType": undefined,
+				  "required": true,
+				  "schema": "string",
+				  "tags": [],
+				  "type": "string",
+				}
+			`);
 
 			const xbar = meta.props.find(prop => prop.name === 'xbar');
 			expect(xbar).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "xbar",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "xbar",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 
 			const xbaz = meta.props.find(prop => prop.name === 'xbaz');
 			expect(xbaz).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "global": false,
-			  "name": "xbaz",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "xbaz",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | undefined",
+				}
+			`);
 
 			const hello = meta.props.find(prop => prop.name === 'hello');
 			expect(hello).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": ""Hello"",
-			  "description": "The hello property.",
-			  "global": false,
-			  "name": "hello",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			    ],
-			    "type": "string | undefined",
-			  },
-			  "tags": [
-			    {
-			      "name": "since",
-			      "text": "v1.0.0",
-			    },
-			  ],
-			  "type": "string | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": ""Hello"",
+				  "description": "The hello property.",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "hello",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				    ],
+				    "type": "string | undefined",
+				  },
+				  "tags": [
+				    {
+				      "name": "since",
+				      "text": "v1.0.0",
+				    },
+				  ],
+				  "type": "string | undefined",
+				}
+			`);
 
 			const numberOrStringProp = meta.props.find(prop => prop.name === 'numberOrStringProp');
 			expect(numberOrStringProp).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": "42",
-			  "description": "",
-			  "global": false,
-			  "name": "numberOrStringProp",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "string",
-			      "number",
-			    ],
-			    "type": "string | number | undefined",
-			  },
-			  "tags": [],
-			  "type": "string | number | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": "42",
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "numberOrStringProp",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "string",
+				      "number",
+				    ],
+				    "type": "string | number | undefined",
+				  },
+				  "tags": [],
+				  "type": "string | number | undefined",
+				}
+			`);
 
 			const arrayProps = meta.props.find(prop => prop.name === 'arrayProps');
 			expect(arrayProps).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": "[42, 43, 44]",
-			  "description": "",
-			  "global": false,
-			  "name": "arrayProps",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      {
-			        "kind": "array",
-			        "schema": [
-			          "unknown",
-			        ],
-			        "type": "unknown[]",
-			      },
-			    ],
-			    "type": "unknown[] | undefined",
-			  },
-			  "tags": [],
-			  "type": "unknown[] | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": "[42, 43, 44]",
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "arrayProps",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      {
+				        "kind": "array",
+				        "schema": [
+				          "unknown",
+				        ],
+				        "type": "unknown[]",
+				      },
+				    ],
+				    "type": "unknown[] | undefined",
+				  },
+				  "tags": [],
+				  "type": "unknown[] | undefined",
+				}
+			`);
 		});
 
 		test('reference-type-events', () => {
@@ -958,99 +1000,105 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 
 			const onFoo = meta.events.find(event => event.name === 'foo');
 			expect(onFoo).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "name": "foo",
-			  "rawType": undefined,
-			  "schema": [
-			    {
-			      "kind": "enum",
-			      "schema": [
-			        "undefined",
-			        {
-			          "kind": "object",
-			          "schema": {
-			            "foo": {
-			              "declarations": [],
-			              "description": "",
-			              "global": false,
-			              "name": "foo",
-			              "rawType": undefined,
-			              "required": true,
-			              "schema": "string",
-			              "tags": [],
-			              "type": "string",
-			            },
-			          },
-			          "type": "{ foo: string; }",
-			        },
-			      ],
-			      "type": "{ foo: string; } | undefined",
-			    },
-			  ],
-			  "signature": "(event: "foo", data?: { foo: string; } | undefined): void",
-			  "tags": [],
-			  "type": "[{ foo: string; } | undefined]",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "name": "foo",
+				  "rawType": undefined,
+				  "schema": [
+				    {
+				      "kind": "enum",
+				      "schema": [
+				        "undefined",
+				        {
+				          "kind": "object",
+				          "schema": {
+				            "foo": {
+				              "declarations": [],
+				              "description": "",
+				              "getTypeObject": [Function],
+				              "global": false,
+				              "name": "foo",
+				              "rawType": undefined,
+				              "required": true,
+				              "schema": "string",
+				              "tags": [],
+				              "type": "string",
+				            },
+				          },
+				          "type": "{ foo: string; }",
+				        },
+				      ],
+				      "type": "{ foo: string; } | undefined",
+				    },
+				  ],
+				  "signature": "(event: "foo", data?: { foo: string; } | undefined): void",
+				  "tags": [],
+				  "type": "[{ foo: string; } | undefined]",
+				}
+			`);
 
 			const onBar = meta.events.find(event => event.name === 'bar');
 			expect(onBar).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "name": "bar",
-			  "rawType": undefined,
-			  "schema": [
-			    {
-			      "kind": "object",
-			      "schema": {
-			        "arg1": {
-			          "declarations": [],
-			          "description": "",
-			          "global": false,
-			          "name": "arg1",
-			          "rawType": undefined,
-			          "required": true,
-			          "schema": "number",
-			          "tags": [],
-			          "type": "number",
-			        },
-			        "arg2": {
-			          "declarations": [],
-			          "description": "",
-			          "global": false,
-			          "name": "arg2",
-			          "rawType": undefined,
-			          "required": false,
-			          "schema": "any",
-			          "tags": [],
-			          "type": "any",
-			        },
-			      },
-			      "type": "{ arg1: number; arg2?: any; }",
-			    },
-			  ],
-			  "signature": "(event: "bar", value: { arg1: number; arg2?: any; }): void",
-			  "tags": [],
-			  "type": "[{ arg1: number; arg2?: any; }]",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "name": "bar",
+				  "rawType": undefined,
+				  "schema": [
+				    {
+				      "kind": "object",
+				      "schema": {
+				        "arg1": {
+				          "declarations": [],
+				          "description": "",
+				          "getTypeObject": [Function],
+				          "global": false,
+				          "name": "arg1",
+				          "rawType": undefined,
+				          "required": true,
+				          "schema": "number",
+				          "tags": [],
+				          "type": "number",
+				        },
+				        "arg2": {
+				          "declarations": [],
+				          "description": "",
+				          "getTypeObject": [Function],
+				          "global": false,
+				          "name": "arg2",
+				          "rawType": undefined,
+				          "required": false,
+				          "schema": "any",
+				          "tags": [],
+				          "type": "any",
+				        },
+				      },
+				      "type": "{ arg1: number; arg2?: any; }",
+				    },
+				  ],
+				  "signature": "(event: "bar", value: { arg1: number; arg2?: any; }): void",
+				  "tags": [],
+				  "type": "[{ arg1: number; arg2?: any; }]",
+				}
+			`);
 
 			const onBaz = meta.events.find(event => event.name === 'baz');
 			expect(onBaz).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "name": "baz",
-			  "rawType": undefined,
-			  "schema": [],
-			  "signature": "(e: "baz"): void",
-			  "tags": [],
-			  "type": "[]",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "name": "baz",
+				  "rawType": undefined,
+				  "schema": [],
+				  "signature": "(e: "baz"): void",
+				  "tags": [],
+				  "type": "[]",
+				}
+			`);
 		});
 
 		test('reference-type-events w/ generic', () => {
@@ -1061,19 +1109,20 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 
 			const onBar = meta.events.find(event => event.name === 'bar');
 			expect(onBar).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "name": "bar",
-			  "rawType": undefined,
-			  "schema": [
-			    "number",
-			  ],
-			  "signature": "(e: "bar", data: number): void",
-			  "tags": [],
-			  "type": "[number]",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "name": "bar",
+				  "rawType": undefined,
+				  "schema": [
+				    "number",
+				  ],
+				  "signature": "(e: "bar", data: number): void",
+				  "tags": [],
+				  "type": "[number]",
+				}
+			`);
 		});
 
 		test('reference-type-slots', () => {
@@ -1157,15 +1206,16 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 
 			const counter = meta.exposed.find(exposed => exposed.name === 'counter');
 			expect(counter).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "a counter string",
-			  "name": "counter",
-			  "rawType": undefined,
-			  "schema": "string",
-			  "type": "string",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "a counter string",
+				  "getTypeObject": [Function],
+				  "name": "counter",
+				  "rawType": undefined,
+				  "schema": "string",
+				  "type": "string",
+				}
+			`);
 		});
 
 		test('component with both props and events', () => {
@@ -1276,69 +1326,73 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 
 			const submitEvent = meta.events.find(evt => evt.name === 'submit');
 			expect(submitEvent).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "description": "",
-			  "name": "submit",
-			  "rawType": undefined,
-			  "schema": [
-			    {
-			      "kind": "object",
-			      "schema": {
-			        "email": {
-			          "declarations": [],
-			          "description": "email of user",
-			          "global": false,
-			          "name": "email",
-			          "rawType": undefined,
-			          "required": true,
-			          "schema": "string",
-			          "tags": [],
-			          "type": "string",
-			        },
-			        "password": {
-			          "declarations": [],
-			          "description": "password of same user",
-			          "global": false,
-			          "name": "password",
-			          "rawType": undefined,
-			          "required": true,
-			          "schema": "string",
-			          "tags": [],
-			          "type": "string",
-			        },
-			      },
-			      "type": "SubmitPayload",
-			    },
-			  ],
-			  "signature": "(event: "submit", args_0: SubmitPayload): void",
-			  "tags": [],
-			  "type": "[SubmitPayload]",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "description": "",
+				  "getTypeObject": [Function],
+				  "name": "submit",
+				  "rawType": undefined,
+				  "schema": [
+				    {
+				      "kind": "object",
+				      "schema": {
+				        "email": {
+				          "declarations": [],
+				          "description": "email of user",
+				          "getTypeObject": [Function],
+				          "global": false,
+				          "name": "email",
+				          "rawType": undefined,
+				          "required": true,
+				          "schema": "string",
+				          "tags": [],
+				          "type": "string",
+				        },
+				        "password": {
+				          "declarations": [],
+				          "description": "password of same user",
+				          "getTypeObject": [Function],
+				          "global": false,
+				          "name": "password",
+				          "rawType": undefined,
+				          "required": true,
+				          "schema": "string",
+				          "tags": [],
+				          "type": "string",
+				        },
+				      },
+				      "type": "SubmitPayload",
+				    },
+				  ],
+				  "signature": "(event: "submit", args_0: SubmitPayload): void",
+				  "tags": [],
+				  "type": "[SubmitPayload]",
+				}
+			`);
 
 			const propNumberDefault = meta.props.find(prop => prop.name === 'numberDefault');
 			expect(propNumberDefault).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": "42",
-			  "description": "Default number",
-			  "global": false,
-			  "name": "numberDefault",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      "number",
-			    ],
-			    "type": "number | undefined",
-			  },
-			  "tags": [],
-			  "type": "number | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": "42",
+				  "description": "Default number",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "numberDefault",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      "number",
+				    ],
+				    "type": "number | undefined",
+				  },
+				  "tags": [],
+				  "type": "number | undefined",
+				}
+			`);
 
 			const propObjectDefault = meta.props.find(prop => prop.name === 'objectDefault');
 			expect(propObjectDefault).toMatchInlineSnapshot(`
@@ -1348,6 +1402,7 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 				    foo: "bar",
 				}",
 				  "description": "Default function Object",
+				  "getTypeObject": [Function],
 				  "global": false,
 				  "name": "objectDefault",
 				  "rawType": undefined,
@@ -1367,32 +1422,33 @@ const worker = (checker: ComponentMetaChecker, withTsconfig: boolean) =>
 
 			const propArrayDefault = meta.props.find(prop => prop.name === 'arrayDefault');
 			expect(propArrayDefault).toMatchInlineSnapshot(`
-			{
-			  "declarations": [],
-			  "default": "[1, 2, 3]",
-			  "description": "Default function Array",
-			  "global": false,
-			  "name": "arrayDefault",
-			  "rawType": undefined,
-			  "required": false,
-			  "schema": {
-			    "kind": "enum",
-			    "schema": [
-			      "undefined",
-			      {
-			        "kind": "array",
-			        "schema": [
-			          "unknown",
-			        ],
-			        "type": "unknown[]",
-			      },
-			    ],
-			    "type": "unknown[] | undefined",
-			  },
-			  "tags": [],
-			  "type": "unknown[] | undefined",
-			}
-		`);
+				{
+				  "declarations": [],
+				  "default": "[1, 2, 3]",
+				  "description": "Default function Array",
+				  "getTypeObject": [Function],
+				  "global": false,
+				  "name": "arrayDefault",
+				  "rawType": undefined,
+				  "required": false,
+				  "schema": {
+				    "kind": "enum",
+				    "schema": [
+				      "undefined",
+				      {
+				        "kind": "array",
+				        "schema": [
+				          "unknown",
+				        ],
+				        "type": "unknown[]",
+				      },
+				    ],
+				    "type": "unknown[] | undefined",
+				  },
+				  "tags": [],
+				  "type": "unknown[] | undefined",
+				}
+			`);
 		});
 
 		test('component-name-description (vue)', () => {


### PR DESCRIPTION
Resolves #5402

Add functions to expose TS data.

- `rawType` -> `getTypeObject()`
- `__internal__.tsLs.getProgram()` -> `getProgram()`