### PR TITLE
perf(language-core): dedupe component options generation

### DIFF
--- a/packages/language-core/lib/codegen/names.ts
+++ b/packages/language-core/lib/codegen/names.ts
@@ -1,5 +1,4 @@
 export const ctx = '__VLS_ctx';
-export const self = '__VLS_self';
 export const dollars = '__VLS_dollars';
 export const slots = '__VLS_slots';
 export const props = '__VLS_props';

--- a/packages/language-core/lib/codegen/script/index.ts
+++ b/packages/language-core/lib/codegen/script/index.ts
@@ -163,7 +163,7 @@ function* generateWorker(
 			yield* generateSfcBlockSection(script, 0, expression.start, codeFeatures.all);
 			yield exportExpression;
 			yield endOfLine;
-			yield* generateTemplate(options, ctx);
+			yield* generateTemplate(options, ctx, names._export);
 			yield* generateExportDeclareEqual(script);
 			if (wrapLeft && wrapRight) {
 				yield wrapLeft;
@@ -179,7 +179,7 @@ function* generateWorker(
 			yield* generateSfcBlockSection(script, 0, script.content.length, codeFeatures.all);
 			yield* generateExportDeclareEqual(script);
 			yield `(await import('${vueCompilerOptions.lib}')).defineComponent({})${endOfLine}`;
-			yield* generateTemplate(options, ctx);
+			yield* generateTemplate(options, ctx, names._export);
 			yield `export default ${exportExpression}${endOfLine}`;
 		}
 	}

--- a/packages/language-core/lib/codegen/script/src.ts
+++ b/packages/language-core/lib/codegen/script/src.ts
@@ -8,20 +8,7 @@ export function* generateSrc(src: SfcBlockAttr): Generator<Code> {
 		return;
 	}
 	let { text } = src;
-
-	if (text.endsWith('.d.ts')) {
-		text = text.slice(0, -'.d.ts'.length);
-	}
-	else if (text.endsWith('.ts')) {
-		text = text.slice(0, -'.ts'.length);
-	}
-	else if (text.endsWith('.tsx')) {
-		text = text.slice(0, -'.tsx'.length) + '.jsx';
-	}
-
-	if (!text.endsWith('.js') && !text.endsWith('.jsx')) {
-		text = text + '.js';
-	}
+	text = resolveSrcPath(text);
 
 	yield `export * from `;
 	const wrapCodeFeatures: VueCodeInformation = {
@@ -36,4 +23,20 @@ export function* generateSrc(src: SfcBlockAttr): Generator<Code> {
 	yield endBoundary(token, src.offset + src.text.length);
 	yield endOfLine;
 	yield `export { default } from '${text}'${endOfLine}`;
+}
+
+export function resolveSrcPath(text: string): string {
+	if (text.endsWith('.d.ts')) {
+		text = text.slice(0, -'.d.ts'.length);
+	}
+	else if (text.endsWith('.ts')) {
+		text = text.slice(0, -'.ts'.length);
+	}
+	else if (text.endsWith('.tsx')) {
+		text = text.slice(0, -'.tsx'.length) + '.jsx';
+	}
+	if (!text.endsWith('.js') && !text.endsWith('.jsx')) {
+		text = text + '.js';
+	}
+	return text;
 }

--- a/packages/language-server/tests/renaming.spec.ts
+++ b/packages/language-server/tests/renaming.spec.ts
@@ -694,16 +694,6 @@ test('Component returns', async () => {
 		      "file": "\${testWorkspacePath}/tsconfigProject/fixture.vue",
 		      "locs": [
 		        {
-		          "end": {
-		            "line": 3,
-		            "offset": 11,
-		          },
-		          "start": {
-		            "line": 3,
-		            "offset": 8,
-		          },
-		        },
-		        {
 		          "contextEnd": {
 		            "line": 12,
 		            "offset": 13,
@@ -719,6 +709,16 @@ test('Component returns', async () => {
 		          "start": {
 		            "line": 12,
 		            "offset": 7,
+		          },
+		        },
+		        {
+		          "end": {
+		            "line": 3,
+		            "offset": 11,
+		          },
+		          "start": {
+		            "line": 3,
+		            "offset": 8,
 		          },
 		        },
 		      ],


### PR DESCRIPTION
For the following SFC:

```html
<script lang="ts">
import { defineComponent } from 'vue'

export default defineComponent({
  props: {
    foo: {
		type: String,
	},
  }
})
</script>
```

Before virtual code:

```ts
/// <reference types="../node_modules/.vue-global-types/vue_3.5_0.d.ts" />

import { defineComponent } from 'vue'

export default {} as typeof __VLS_export;
const __VLS_self = (await import('vue')).defineComponent({
  props: {
    foo: {
		type: String,
	},
  }
});
const __VLS_ctx = {} as InstanceType<__VLS_PickNotAny<typeof __VLS_self, new () => {}>>;
type __VLS_LocalComponents = typeof __VLS_ctx;
let ___VLS_components!: __VLS_LocalComponents & __VLS_GlobalComponents;
type __VLS_LocalDirectives = typeof __VLS_ctx;
let ___VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
const __VLS_export = defineComponent({
  props: {
    foo: {
		type: String,
	},
  }
})
```

After virtual code:

```ts
/// <reference types="../node_modules/.vue-global-types/vue_3.5_0.d.ts" />

import { defineComponent } from 'vue'

export default {} as typeof __VLS_export;
const __VLS_ctx = {} as InstanceType<__VLS_PickNotAny<typeof __VLS_export, new () => {}>>;
type __VLS_LocalComponents = typeof __VLS_ctx;
let ___VLS_components!: __VLS_LocalComponents & __VLS_GlobalComponents;
type __VLS_LocalDirectives = typeof __VLS_ctx;
let ___VLS_directives!: __VLS_LocalDirectives & __VLS_GlobalDirectives;
const __VLS_export = defineComponent({
  props: {
    foo: {
		type: String,
	},
  }
})
```