### PR TITLE
feat(language-core): align `v-for` key type with `Object.keys`

### DIFF
--- a/packages/language-core/lib/codegen/globalTypes.ts
+++ b/packages/language-core/lib/codegen/globalTypes.ts
@@ -145,7 +145,7 @@ export function generateGlobalTypes(options: VueCompilerOptions) {
 		: T extends string ? [string, number][]
 		: T extends any[] ? [T[number], number][]
 		: T extends Iterable<infer V> ? [V, number][]
-		: [T[keyof T], keyof T extends string ? keyof T : string, number][];
+		: [T[keyof T], \`\${keyof T}\`, number][];
 	function __VLS_vSlot<S, D extends S>(slot: S, decl?: D):
 		D extends (...args: infer P) => any ? P : any[];
 	function __VLS_asFunctionalDirective<T>(dir: T): T extends import('${lib}').ObjectDirective

--- a/test-workspace/tsc/passedFixtures/vue3/v-for/main.vue
+++ b/test-workspace/tsc/passedFixtures/vue3/v-for/main.vue
@@ -40,7 +40,7 @@
   <!-- recordNumberKey -->
   <div v-for="(val, key, index) in recordNumberKey">
     {{ exactType(val, {} as string) }}
-    {{ exactType(key, {} as string) }}
+    {{ exactType(key, {} as '1' | '2' | '3') }}
     {{ exactType(index, {} as number) }}
   </div>
   <!-- recordUnionKey -->
@@ -64,7 +64,7 @@ const map = new Map<string, number>();
 const obj = { a: '', b: 0 };
 const objUnion = { a: '' } as { a: string } | { a: string, b: number };
 const record: Record<string, string> = { a: '' };
-const recordNumberKey: Record<number, string> = { 1: '' };
+const recordNumberKey: Record<1 | 2 | 3, string> = { 1: '', 2: '', 3: '' };
 const recordUnionKey: Record<'a' | 'b', string> = { 'a': '', 'b': '' };
 const _any = {} as any;
 </script>


### PR DESCRIPTION
- align `v-for` keys to string type, align with vue/core [`Object.keys`](https://github.com/vuejs/core/blob/main/packages/runtime-core/src/helpers/renderList.ts#L107)
- support string-only union type like `'a' | 'b'`
