### PR TITLE
fix(vscode): vue ts highlighting when trailing type alias misses semicolon

### DIFF
--- a/extensions/vscode/syntaxes/vue.tmLanguage.json
+++ b/extensions/vscode/syntaxes/vue.tmLanguage.json
@@ -358,6 +358,16 @@
 							"include": "#tag-stuff"
 						},
 						{
+							"begin": "(?<=>)(?=[^\\n]*<\\/script[\\s>])",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.ts",
+							"patterns": [
+								{
+									"include": "source.ts"
+								}
+							]
+						},
+						{
 							"begin": "(?<=>)",
 							"while": "^(?!\\s*<\\/script[\\s>])",
 							"name": "source.ts",
@@ -420,6 +430,16 @@
 					"patterns": [
 						{
 							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)(?=[^\\n]*<\\/script[\\s>])",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.tsx",
+							"patterns": [
+								{
+									"include": "source.tsx"
+								}
+							]
 						},
 						{
 							"begin": "(?<=>)",
@@ -826,6 +846,16 @@
 							"include": "#tag-stuff"
 						},
 						{
+							"begin": "(?<=>)(?=[^\\n]*<\\/script[\\s>])",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.ts",
+							"patterns": [
+								{
+									"include": "source.ts"
+								}
+							]
+						},
+						{
 							"begin": "(?<=>)",
 							"while": "^(?!\\s*<\\/script[\\s>])",
 							"name": "source.ts",
@@ -843,6 +873,16 @@
 					"patterns": [
 						{
 							"include": "#tag-stuff"
+						},
+						{
+							"begin": "(?<=>)(?=[^\\n]*<\\/script[\\s>])",
+							"end": "(?=<\\/script[\\s>])",
+							"name": "source.tsx",
+							"patterns": [
+								{
+									"include": "source.tsx"
+								}
+							]
 						},
 						{
 							"begin": "(?<=>)",


### PR DESCRIPTION
Fix #2060

- Replace the `end` with `while` in patterns.
  - `end` waits for one terminating match
  - `while` re-checks per line and drops the scope as soon as its condition fails.
- Add extra rule to support single line `<script>`

### Before
<img width="337" height="271" alt="before" src="https://github.com/user-attachments/assets/090b39ea-a99b-449b-b827-84c5ebc029a9" />

### After
<img width="360" height="273" alt="after" src="https://github.com/user-attachments/assets/862937c8-3430-4f4f-8c11-3328d4605988" />