### PR TITLE
fix(typescript-plugin): ignore non-vitepress markdown snapshots

### DIFF
--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -40,7 +40,9 @@ export = createLanguageServicePlugin(
 		const getScriptSnapshot = host.getScriptSnapshot?.bind(host);
 		if (getScriptSnapshot) {
 			host.getScriptSnapshot = fileName => {
-				if (!vueOptions.vitePressExtensions.some(ext => fileName.toLowerCase().endsWith(ext.toLowerCase()))) {
+				const shouldIgnoreMarkdown = fileName.toLowerCase().endsWith('.md')
+					&& !vueOptions.vitePressExtensions.some(ext => fileName.toLowerCase().endsWith(ext.toLowerCase()));
+				if (shouldIgnoreMarkdown) {
 					return;
 				}
 				return getScriptSnapshot(fileName);


### PR DESCRIPTION
Related #5884

<img width="784" height="393" src="https://github.com/user-attachments/assets/0e9664ef-abd9-475c-8d90-13b859f0aa29" />
