### PR TITLE
chore: publish to npm with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check commit message and create tag
         run: |
           COMMIT_MSG=$(git log -1 --pretty=%B)
-          
+
           if [[ $COMMIT_MSG =~ ^(v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
             TAG_NAME="${BASH_REMATCH[1]}"
             git config user.name "github-actions[bot]"
@@ -34,6 +34,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-npm:
+    permissions:
+      contents: read
+      id-token: write # to enable use of OIDC for npm provenance
     runs-on: ubuntu-latest
     needs: [auto-tag]
     if: github.event_name == 'workflow_dispatch' || success()
@@ -46,6 +49,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          registry-url: "https://registry.npmjs.org/"
 
       - name: Install Lerna Lite
         run: pnpm add -g @lerna-lite/cli @lerna-lite/publish
@@ -55,9 +59,6 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: NPM Login
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Publish to NPM
         run: lerna publish from-package --yes


### PR DESCRIPTION
update the release to publish to npm with OIDC, Lerna-Lite (which I maintain) supports OIDC. Publishing with OIDC has multiple advantages, it publishes with Provenance, it also uses short lived token which is also much better for security and finally you no longer need an npm token. 

Please note that **you will** also have to enable Trusted Published **for each package** of the monorepo, for example below is one of Lerna-Lite package. 

For more info, see https://github.com/e18e/ecosystem-issues/issues/201

Please don't merge this PR unless you have already updated **each package** to use Trusted Published as shown below. I assume that you could give it a try with `--dry-run` mode to test it out afterward. 

<img width="795" height="789" alt="image" src="https://github.com/user-attachments/assets/b09d5437-bd9c-4e09-8ca2-67f16bd1d7f6" />

<img width="269" height="263" alt="image" src="https://github.com/user-attachments/assets/23ae687f-ee49-43b3-a56a-39c6e7e3307f" />
