### PR TITLE
fix(language-core): do not infer object keys as string literals in `v-for`

### DIFF
--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -4,7 +4,6 @@ declare global {
 	type __VLS_Elements = __VLS_SpreadMerge<SVGElementTagNameMap, HTMLElementTagNameMap>;
 	type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;
 	type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
-	type __VLS_IsEnum<T> = T extends string | number ? string | number extends T ? false : true : false;
 	type __VLS_SpreadMerge<A, B> = Omit<A, keyof B> & B;
 	type __VLS_WithComponent<
 		N0 extends string,

--- a/packages/language-core/types/template-helpers.d.ts
+++ b/packages/language-core/types/template-helpers.d.ts
@@ -4,6 +4,7 @@ declare global {
 	type __VLS_Elements = __VLS_SpreadMerge<SVGElementTagNameMap, HTMLElementTagNameMap>;
 	type __VLS_IsAny<T> = 0 extends 1 & T ? true : false;
 	type __VLS_PickNotAny<A, B> = __VLS_IsAny<A> extends true ? B : A;
+	type __VLS_IsEnum<T> = T extends string | number ? string | number extends T ? false : true : false;
 	type __VLS_SpreadMerge<A, B> = Omit<A, keyof B> & B;
 	type __VLS_WithComponent<
 		N0 extends string,
@@ -106,11 +107,13 @@ declare global {
 	};
 	type __VLS_PrettifyGlobal<T> = (T extends any ? { [K in keyof T]: T[K] } : { [K in keyof T as K]: T[K] }) & {};
 
-	function __VLS_vFor<T>(source: T): T extends number ? [number, number][]
-		: T extends string ? [string, number][]
-		: T extends (infer U)[] ? [U, number][]
-		: T extends Iterable<infer V> ? [V, number][]
-		: [T[keyof T], `${keyof T & (string | number)}`, number][];
+	function __VLS_vFor<T>(source: T): (
+		T extends number ? [number, number]
+			: T extends string ? [string, number]
+			: T extends (infer U)[] ? [U, number]
+			: T extends Iterable<infer V> ? [V, number]
+			: [T[keyof T], Exclude<keyof T, symbol>, number]
+	)[];
 	function __VLS_vSlot<S, D extends S>(slot: S, decl?: D): D extends (...args: infer P) => any ? P : any[];
 	function __VLS_asFunctionalDirective<T, ObjectDirective>(
 		dir: T,

--- a/test-workspace/tsc/v-for/main.vue
+++ b/test-workspace/tsc/v-for/main.vue
@@ -40,13 +40,19 @@
   <!-- recordNumberKey -->
   <div v-for="(val, key, index) in recordNumberKey">
     {{ exactType(val, {} as string) }}
-    {{ exactType(key, {} as '1' | '2' | '3') }}
+    {{ exactType(key, {} as 1 | 2 | 3) }}
     {{ exactType(index, {} as number) }}
   </div>
   <!-- recordUnionKey -->
   <div v-for="(val, key, index) in recordUnionKey">
     {{ exactType(val, {} as string) }}
     {{ exactType(key, {} as 'a' | 'b') }}
+    {{ exactType(index, {} as number) }}
+  </div>
+  <!-- recordEnumKey -->
+  <div v-for="(val, key, index) in recordEnumKey">
+    {{ exactType(val, {} as string) }}
+    {{ exactType(key, {} as Enum) }}
     {{ exactType(index, {} as number) }}
   </div>
   <!-- any -->
@@ -59,6 +65,11 @@
 <script setup lang="ts">
 import { exactType } from '../shared';
 
+enum Enum {
+  A = 1,
+  B = '2',
+}
+
 const arr = ['a', 'b'] as const;
 const map = new Map<string, number>();
 const obj = { a: '', b: 0 };
@@ -66,5 +77,6 @@ const objUnion = { a: '' } as { a: string } | { a: string, b: number };
 const record: Record<string, string> = { a: '' };
 const recordNumberKey: Record<1 | 2 | 3, string> = { 1: '', 2: '', 3: '' };
 const recordUnionKey: Record<'a' | 'b', string> = { 'a': '', 'b': '' };
+const recordEnumKey: Record<Enum, string> = { [Enum.A]: '', [Enum.B]: '' };
 const _any = {} as any;
 </script>


### PR DESCRIPTION
fix #5927

Both `for ... in` and `Object.keys()` just return `string`. Current v-for implement in language tools is not consistent with TS behavior. Inferring the type of key as `Exclude<keyof T, symbol>` instead of `string` should be the maximum concession we can make.