### PR TITLE
fix(language-service): use default html data provider for document symbols

### DIFF
--- a/packages/language-service/lib/plugins/vue-template.ts
+++ b/packages/language-service/lib/plugins/vue-template.ts
@@ -618,7 +618,7 @@ export function create(
 				sourceDocumentUri: URI,
 				root: VueVirtualCode,
 				hint: string | undefined,
-				mode: 'completion' | 'hover' | 'outline',
+				mode: 'completion' | 'hover',
 				fn: () => T,
 			) {
 				// #4298: Precompute HTMLDocument before provideHtmlData to avoid parseHTMLDocument requesting component names from tsserver
@@ -637,7 +637,7 @@ export function create(
 				sourceDocumentUri: URI,
 				root: VueVirtualCode,
 				hint: string | undefined,
-				mode: 'completion' | 'hover' | 'outline',
+				mode: 'completion' | 'hover',
 			) {
 				const [tagNameCasing, attrNameCasing] = await Promise.all([
 					getTagNameCasing(context, sourceDocumentUri),


### PR DESCRIPTION
close #5967

Now data provider run after you do hover / completion action, but not for document symbol requests, may cause make outline / breadcrumbs display differently before and after editing