### PR TITLE
fix(language-core): re-parse template when interpolation syntax breaks

### DIFF
--- a/packages/language-core/lib/plugins/vue-template-html.ts
+++ b/packages/language-core/lib/plugins/vue-template-html.ts
@@ -179,8 +179,11 @@ const plugin: VueLanguagePlugin = ({ modules }) => {
 						if (!tryUpdateNode(node.content)) {
 							return false;
 						}
-						if (node.content.loc.source.includes('{{') || node.content.loc.source.includes('}}')) {
-							return false;
+						if (node.content.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {
+							const { content } = node.content;
+							if (content.includes('{{') || content.includes('}}')) {
+								return false;
+							}
 						}
 					}
 					else if (node.type === CompilerDOM.NodeTypes.SIMPLE_EXPRESSION) {


### PR DESCRIPTION
close #5964

preview:
![Peek 2026-02-19 00-01](https://github.com/user-attachments/assets/d32ab682-f258-4ffd-aafb-e07a19a3c303)