### PR TITLE
fix(vscode): use regex for TS extension patching to support VS Code 1.110+

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -328,25 +328,43 @@ function patchTypeScriptExtension() {
 		if (args[0] === extensionJsPath) {
 			let text = readFileSync(...args) as string;
 
+			const id = String.raw`[\w$]+(?:\.[\w$]+)?`;
+
 			// patch jsTsLanguageModes
+			// before 1.110: t.jsTsLanguageModes=[t.javascript,t.javascriptreact,t.typescript,t.typescriptreact]
+			// since 1.110:  "javascriptreact",Oh=[Ma,Ua,bl,Ns]
 			text = text.replace(
-				't.jsTsLanguageModes=[t.javascript,t.javascriptreact,t.typescript,t.typescriptreact]',
-				s => s + '.concat("vue")',
+				new RegExp(
+					String
+						.raw`(\.jsTsLanguageModes=\[${id},${id},${id},${id}\])|("javascriptreact",(${id})=\[(${id},${id},${id},${id})\])`,
+				),
+				(_match, oldFormat, _newFull, newLhs, newElements) => {
+					if (oldFormat) {
+						return oldFormat + '.concat("vue")';
+					}
+					return `"javascriptreact",${newLhs}=[${newElements}].concat("vue")`;
+				},
 			);
-			// patch isSupportedLanguageMode
+			// patch isSupportedLanguageMode (4 language IDs)
+			// before 1.110: .languages.match([t.typescript,t.typescriptreact,t.javascript,t.javascriptreact]
+			// since 1.110:  .languages.match([bl,Ns,Ma,Ua],r)>0
 			text = text.replace(
-				'.languages.match([t.typescript,t.typescriptreact,t.javascript,t.javascriptreact]',
-				s => s + '.concat("vue")',
+				new RegExp(String.raw`\.languages\.match\(\[(${id},${id},${id},${id})\]`),
+				(_, ids) => `.languages.match([${ids}].concat("vue")`,
 			);
-			// patch isTypeScriptDocument
+			// patch isTypeScriptDocument (2 language IDs)
+			// before 1.110: .languages.match([t.typescript,t.typescriptreact]
+			// since 1.110:  .languages.match([bl,Ns],r)>0
 			text = text.replace(
-				'.languages.match([t.typescript,t.typescriptreact]',
-				s => s + '.concat("vue")',
+				new RegExp(String.raw`\.languages\.match\(\[(${id},${id})\]`),
+				(_, ids) => `.languages.match([${ids}].concat("vue")`,
 			);
 
 			// sort plugins for johnsoncodehk.tsslint, zardoy.ts-essential-plugins
+			// before 1.110: "--globalPlugins",i.plugins
+			// since 1.110:  "--globalPlugins",o.plugins.map(v=>v.name).join(","))
 			text = text.replace(
-				'"--globalPlugins",i.plugins',
+				/"--globalPlugins",([\w$]+)\.plugins/,
 				s => s + `.sort((a,b)=>(b.name==="${tsPluginName}"?-1:0)-(a.name==="${tsPluginName}"?-1:0))`,
 			);
 


### PR DESCRIPTION
## Summary

- VS Code 1.110 switched its extension build system from `tsb` to `tsgo` (microsoft/vscode#292461), changing the minified variable names in the built-in TypeScript extension's `dist/extension.js`
- The hardcoded string patterns in `patchTypeScriptExtension()` no longer matched, causing the monkey-patches to silently fail
- This broke "Find File References" and other TypeScript features for `.vue` files, because `isSupportedLanguageMode` no longer included `vue`

This PR replaces the four hardcoded string replacements with regex-based patterns that match identifier names regardless of minification, supporting both the old format (`t.typescript`, `t.jsTsLanguageModes`) and the new format (`bl`, `Oh`).

Fixes https://github.com/vuejs/language-tools/issues/4221#issuecomment-4036019402