### PR TITLE
fix(language-service): avoid false positives for destructured props detection on binding property names

### DIFF
--- a/packages/language-service/lib/plugins/vue-inlayhints.ts
+++ b/packages/language-service/lib/plugins/vue-inlayhints.ts
@@ -317,6 +317,16 @@ export function findDestructuredProps(
 			}
 		}
 
+		if (
+			ts.isBindingElement(parent)
+			|| ts.isImportSpecifier(parent)
+			|| ts.isExportSpecifier(parent)
+		) {
+			if (parent.propertyName === id) {
+				return false;
+			}
+		}
+
 		return true;
 	}
 }


### PR DESCRIPTION
fix #5993