### PR TITLE
fix(vscode): do not access config before activate is called

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -21,9 +21,6 @@ import { restrictFormattingEditsToRange } from './rangeFormatting';
 import * as reactivityVisualization from './reactivityVisualization';
 import * as welcome from './welcome';
 
-let serverPath = resolveServerPath();
-const neededRestart = !patchTypeScriptExtension();
-
 for (
 	const incompatibleExtensionId of [
 		'johnsoncodehk.vscode-typescript-vue-plugin',
@@ -46,6 +43,8 @@ for (
 const logger = defineLogger('Vue Language Server');
 
 export = defineExtension(() => {
+	let serverPath = resolveServerPath();
+	const neededRestart = !patchTypeScriptExtension();
 	let client: lsp.BaseLanguageClient | undefined;
 
 	const context = extensionContext.value!;


### PR DESCRIPTION
`resolveServerPath()` and `patchTypeScriptExtension()` were being called at module top level, causing `config.server.path` and `config.server.includeLanguages` to be read before the extension is activated.

This moves both calls inside the `defineExtension` callback so they run after `activate`.