### PR TITLE
fix(vscode): avoid infinite diagnostics on Vue files when project diagnostics is enabled

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -335,7 +335,7 @@ function patchTypeScriptExtension() {
 			// patch standardFileExtensions
 			text = text.replace(
 				new RegExp(String.raw`registerExtensionLanguageProvider\((${id}),${id}\)\{`),
-				(match, id) => `${match}if(${id}.languages.includes("vue"))${id}.standardFileExtensions.push("vue");`,
+				(match, id) => `${match}if(${id}.languageIds.includes("vue"))${id}.standardFileExtensions.push("vue");`,
 			);
 			// patch configureOptions
 			text = text.replace(

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -332,6 +332,11 @@ function patchTypeScriptExtension() {
 				new RegExp(String.raw`\.languages\.match\(\[(${id},${id})\]`),
 				(_, ids) => `.languages.match([${ids}].concat("vue")`,
 			);
+			// patch standardFileExtensions
+			text = text.replace(
+				new RegExp(String.raw`registerExtensionLanguageProvider\((${id}),${id}\)\{`),
+				(match, id) => `${match}if(${id}.languages.includes("vue"))${id}.standardFileExtensions.push("vue");`,
+			);
 			// patch configureOptions
 			text = text.replace(
 				new RegExp(String.raw`this.executeWithoutWaitingForResponse\("configure",(${id})`),
@@ -340,8 +345,8 @@ function patchTypeScriptExtension() {
 			);
 			// patch getJsTsFileBeingMoved
 			text = text.replace(
-				new RegExp(String.raw`.RelativePattern\((${id}),"\*\*\/\*\.\{(ts,tsx,js,jsx)`),
-				(_, resource, ids) => `.RelativePattern(${resource},"**/*.{${ids},vue`,
+				new RegExp(String.raw`.RelativePattern\(${id},"\*\*\/\*\.\{ts,tsx,js,jsx`),
+				match => `${match},vue`,
 			);
 
 			// sort plugins for johnsoncodehk.tsslint, zardoy.ts-essential-plugins

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -337,7 +337,7 @@ function patchTypeScriptExtension() {
 				new RegExp(String.raw`registerExtensionLanguageProvider\((${id}),${id}\)\{`),
 				(match, id) => `${match}if(${id}.languageIds.includes("vue"))${id}.standardFileExtensions.push("vue");`,
 			);
-			// patch configureOptions
+			// patch extraFileExtensions
 			text = text.replace(
 				new RegExp(String.raw`this.executeWithoutWaitingForResponse\("configure",(${id})`),
 				(match, id) =>


### PR DESCRIPTION
fix #4519

1. `js/ts.tsserver.experimental.enableProjectDiagnostics` is enabled
2. TS client sends [`geterrForProject`](https://github.com/microsoft/vscode/blob/2f8a3beb/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts#L309-L313) request
3. TS client [received diagnostics](https://github.com/microsoft/vscode/blob/2f8a3beb/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts#L94-L96) of all Vue files in the project
4. TS client tries to [get language](https://github.com/microsoft/vscode/blob/2f8a3beb/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts#L241) of the corresponding URI
5. TS client tries to [handle URI](https://github.com/microsoft/vscode/blob/2f8a3beb/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts#L206) first, but [failed](https://github.com/microsoft/vscode/blob/2f8a3beb/extensions/typescript-language-features/src/languageProvider.ts#L104) since `standardFileExtensions` derived from plugin entry [is empty](https://github.com/microsoft/vscode/blob/2f8a3beb/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts#L134)
6. TS client runs [`openTextDocument`](https://github.com/microsoft/vscode/blob/2f8a3beb/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts#L214) with this URI
7. TS client [requests diagnostics](https://github.com/microsoft/vscode/blob/2f8a3beb/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts#L611) again!