### PR TITLE
fix(typescript-plugin): skip unchecked JS identifiers in component props

### DIFF
--- a/packages/typescript-plugin/lib/requests/getComponentProps.ts
+++ b/packages/typescript-plugin/lib/requests/getComponentProps.ts
@@ -70,7 +70,6 @@ export function getComponentProps(
 		return [];
 	}
 
-	const checker = program.getTypeChecker();
 	const completion = tsLanguageService.getCompletionsAtPosition(virtualCode.fileName, position2, {
 		includeSymbol: true,
 	});
@@ -81,6 +80,7 @@ export function getComponentProps(
 	}
 
 	const props: ComponentPropInfo[] = [];
+	const checker = program.getTypeChecker();
 
 	for (const entry of completion.entries) {
 		// skip unchecked JS identifiers

--- a/packages/typescript-plugin/lib/requests/getComponentProps.ts
+++ b/packages/typescript-plugin/lib/requests/getComponentProps.ts
@@ -80,7 +80,14 @@ export function getComponentProps(
 		return [];
 	}
 
-	return completion.entries.map(entry => {
+	const props: ComponentPropInfo[] = [];
+
+	for (const entry of completion.entries) {
+		// skip unchecked JS identifiers
+		if (entry.isFromUncheckedFile) {
+			continue;
+		}
+
 		const modifiers = entry.kindModifiers?.split(',');
 		const type = entry.symbol && checker.getTypeOfSymbol(entry.symbol);
 
@@ -102,6 +109,9 @@ export function getComponentProps(
 		if (type && hasBooleanType(ts, type)) {
 			info.boolean = true;
 		}
-		return info;
-	});
+
+		props.push(info);
+	}
+
+	return props;
 }


### PR DESCRIPTION
fix #6054