### PR TITLE
fix(language-core): avoid extraneous children error for conditional slots

### DIFF
--- a/packages/language-core/lib/template/transforms/transformElement.ts
+++ b/packages/language-core/lib/template/transforms/transformElement.ts
@@ -78,9 +78,11 @@ export const transformElement: NodeTransform = (node, context) => {
 			const onComponentSlot = findDir(node, 'slot', true);
 
 			for (let child of node.children) {
+				// <template v-for> -> for > template
 				if (child.type === NodeTypes.FOR) {
 					child = child.children[0]!;
 				}
+				// <template v-if> -> if > branch > template
 				else if (child.type === NodeTypes.IF) {
 					child = child.branches[0]!.children[0]!;
 				}

--- a/packages/language-core/lib/template/transforms/transformElement.ts
+++ b/packages/language-core/lib/template/transforms/transformElement.ts
@@ -72,13 +72,19 @@ export const transformElement: NodeTransform = (node, context) => {
 		}
 
 		if (isComponent) {
-			let hasTemplateSlots = false;
 			let hasNamedDefaultSlot = false;
 			const implicitDefaultChildren: TemplateChildNode[] = [];
 			const seenSlotNames = new Set<string>();
 			const onComponentSlot = findDir(node, 'slot', true);
 
-			for (const child of node.children) {
+			for (let child of node.children) {
+				if (child.type === NodeTypes.FOR) {
+					child = child.children[0]!;
+				}
+				else if (child.type === NodeTypes.IF) {
+					child = child.branches[0]!.children[0]!;
+				}
+
 				let slotDir: DirectiveNode | undefined;
 				if (!isTemplateNode(child) || !(slotDir = findDir(child, 'slot', true))) {
 					if (child.type !== NodeTypes.COMMENT) {
@@ -94,11 +100,6 @@ export const transformElement: NodeTransform = (node, context) => {
 					break;
 				}
 
-				if (findDir(child, /^(?:if|else-if|else|for)$/, true)) {
-					continue;
-				}
-
-				hasTemplateSlots = true;
 				const staticSlotName = slotDir.arg
 					? isStaticExp(slotDir.arg)
 						? slotDir.arg.content
@@ -120,7 +121,7 @@ export const transformElement: NodeTransform = (node, context) => {
 			}
 
 			if (
-				hasTemplateSlots && hasNamedDefaultSlot
+				hasNamedDefaultSlot
 				&& implicitDefaultChildren.some(node => node.type !== NodeTypes.TEXT || !!node.content.trim())
 			) {
 				context.onError(


### PR DESCRIPTION
fix #6053