### PR TITLE
fix(vscode): resolve typescript plugin path from resolved server path

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -262,7 +262,7 @@ function resolveServerPath() {
 	) {
 		try {
 			const entryFile = require.resolve('./index.js', { paths: [serverPath] });
-			const tsPluginPath = require.resolve('@vue/typescript-plugin', { paths: [serverPath] });
+			const tsPluginPath = require.resolve('@vue/typescript-plugin', { paths: [path.dirname(entryFile)] });
 			// FIXME: cannot work on read-only file system
 			fs.writeFileSync(tsPluginEntry, `module.exports = require(${JSON.stringify(tsPluginPath)});`);
 			return entryFile;


### PR DESCRIPTION
fix #6057